### PR TITLE
docs(name): Change references of MSstatsPPI to MSstatsBioNet

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,4 +1,4 @@
-Package: MSstatsPPI
+Package: MSstatsBioNet
 Type: Package
 Title: Protein-Protein Interaction Analysis for MS-based Proteomics Experiments
 Version: 0.1.0
@@ -8,9 +8,9 @@ Authors@R: c(
     person("Olga", "Vitek", email = "o.vitek@northeastern.edu", 
         role = "aut", comment=c(ORCID = "0000-0003-1728-1104"))) 
 Description: A set of tools for protein-protein interaction analysis using mass 
-    spectrometry-based proteomics data and PPI databases. The package takes as 
-    input the output of MSstats differential abundance analysis and provides 
-    functions to perform PPI enrichment analysis and visualization in the 
+    spectrometry-based proteomics data and network databases. The package takes 
+    as input the output of MSstats differential abundance analysis and provides 
+    functions to perform enrichment analysis and visualization in the 
     context of prior knowledge from past literature. Notably, this package 
     integrates with INDRA, which is a database of protein-protein interactions 
     extracted from the literature using text mining techniques.
@@ -31,7 +31,7 @@ VignetteBuilder: knitr
 biocViews: ImmunoOncology, MassSpectrometry, Proteomics, Software, 
     QualityControl
 Encoding: UTF-8
-URL: http://msstats.org, https://vitek-lab.github.io/MSstatsPPI/
+URL: http://msstats.org, https://vitek-lab.github.io/MSstatsBioNet/
 BugReports: https://groups.google.com/forum/#!forum/msstats
 Config/testthat/edition: 3
 RoxygenNote: 7.3.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,3 @@
-# MSstatsPPI 0.1.0
+# MSstatsBioNet 0.1.0
 
 * Added a `NEWS.md` file to track changes to the package.

--- a/R/getSubnetworkFromIndra.R
+++ b/R/getSubnetworkFromIndra.R
@@ -12,7 +12,7 @@
 #' @examples
 #' input <- data.table::fread(system.file(
 #'     "processed_data/groupComparisonModel.csv",
-#'     package = "MSstatsPPI"
+#'     package = "MSstatsBioNet"
 #' ))
 #' # subnetwork = getSubnetworkFromIndra(input, pvalue_cutoff = 0.05)
 #' # head(subnetwork$nodes)

--- a/R/visualizeSubnetwork.R
+++ b/R/visualizeSubnetwork.R
@@ -14,7 +14,7 @@
 #' @examples
 #' input <- data.table::fread(system.file(
 #'     "processed_data/groupComparisonModel.csv",
-#'     package = "MSstatsPPI"
+#'     package = "MSstatsBioNet"
 #' ))
 #' # subnetwork = getSubnetworkFromIndra(input)
 #' # visualizeSubnetwork(subnetwork$nodes, subnetwork$edges)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# MSstatsPPI
+# MSstatsBioNet
 
-This package provides a suite of functions to query various PPI databases, filter queries & results, and visualize PPIs.
+This package provides a suite of functions to query various network databases, 
+filter queries & results, and visualize networks.
 
 ## Databases Supported
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://vitek-lab.github.io/MSstatsPPI/
+url: https://vitek-lab.github.io/MSstatsBioNet/
 template:
   bootstrap: 5
 

--- a/man/getSubnetworkFromIndra.Rd
+++ b/man/getSubnetworkFromIndra.Rd
@@ -22,7 +22,7 @@ Get subnetwork from INDRA database with differential analysis results
 \examples{
 input <- data.table::fread(system.file(
     "processed_data/groupComparisonModel.csv",
-    package = "MSstatsPPI"
+    package = "MSstatsBioNet"
 ))
 # subnetwork = getSubnetworkFromIndra(input, pvalue_cutoff = 0.05)
 # head(subnetwork$nodes)

--- a/man/visualizeSubnetwork.Rd
+++ b/man/visualizeSubnetwork.Rd
@@ -26,7 +26,7 @@ Create visualization of subnetwork in cytoscape
 \examples{
 input <- data.table::fread(system.file(
     "processed_data/groupComparisonModel.csv",
-    package = "MSstatsPPI"
+    package = "MSstatsBioNet"
 ))
 # subnetwork = getSubnetworkFromIndra(input)
 # visualizeSubnetwork(subnetwork$nodes, subnetwork$edges)

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -7,6 +7,6 @@
 # * https://testthat.r-lib.org/articles/special-files.html
 
 library(testthat)
-library(MSstatsPPI)
+library(MSstatsBioNet)
 
-test_check("MSstatsPPI")
+test_check("MSstatsBioNet")

--- a/tests/testthat/test-getSubnetworkFromIndra.R
+++ b/tests/testthat/test-getSubnetworkFromIndra.R
@@ -1,9 +1,9 @@
 test_that("getSubnetworkFromIndra works correctly", {
     input <- data.table::fread(
-        system.file("processed_data/groupComparisonModel.csv", package = "MSstatsPPI")
+        system.file("processed_data/groupComparisonModel.csv", package = "MSstatsBioNet")
     )
     local_mocked_bindings(.callIndraCogexApi = function(x) {
-        return(readRDS(system.file("processed_data/indraResponse.rds", package = "MSstatsPPI")))
+        return(readRDS(system.file("processed_data/indraResponse.rds", package = "MSstatsBioNet")))
     })
     subnetwork <- getSubnetworkFromIndra(input)
     expect_equal(nrow(subnetwork$nodes), 4)
@@ -12,10 +12,10 @@ test_that("getSubnetworkFromIndra works correctly", {
 
 test_that("getSubnetworkFromIndra with pvalue filter works correctly", {
     input <- data.table::fread(
-        system.file("processed_data/groupComparisonModel.csv", package = "MSstatsPPI")
+        system.file("processed_data/groupComparisonModel.csv", package = "MSstatsBioNet")
     )
     local_mocked_bindings(.callIndraCogexApi = function(x) {
-        return(readRDS(system.file("processed_data/indraResponse.rds", package = "MSstatsPPI")))
+        return(readRDS(system.file("processed_data/indraResponse.rds", package = "MSstatsBioNet")))
     })
     subnetwork <- getSubnetworkFromIndra(input, pvalue_cutoff = 0.05)
     expect_equal(nrow(subnetwork$nodes), 3)

--- a/vignettes/MSstatsBioNet.Rmd
+++ b/vignettes/MSstatsBioNet.Rmd
@@ -1,8 +1,8 @@
 ---
-title: "MSstatsPPI"
+title: "MSstatsBioNet"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{MSstatsPPI: Introduction}
+  %\VignetteIndexEntry{MSstatsBioNet: Introduction}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
@@ -15,26 +15,26 @@ knitr::opts_chunk$set(
 ```
 
 ```{r setup}
-library(MSstatsPPI)
+library(MSstatsBioNet)
 ```
 
-# Purpose of MSstatsPPI
+# Purpose of MSstatsBioNet
   
-The `MSstatsPPI` package is a member of the `MSstats` family of packages.
+The `MSstatsBioNet` package is a member of the `MSstats` family of packages.
 It contains a set of functions for interpretation of mass spectrometry (MS) 
 statistical analysis results in the context of protein-protein interaction 
-(PPI) networks. The package is designed to be used in conjunction with the 
+networks. The package is designed to be used in conjunction with the 
 `MSstats` package.
 
 The package provides a function `getSubnetworkFromIndra` that retrieves a
-subnetwork of PPIs from the INDRA database based on differential abundance
+subnetwork of proteins from the INDRA database based on differential abundance
 analysis results.  The function `visualizeSubnetwork` then takes the output
 of `getSubnetworkFromIndra` and visualizes the subnetwork.
 
 ```{r proteinNetworkDiscovery, eval=FALSE}
 input <- data.table::fread(
     system.file("processed_data/groupComparisonModel.csv",
-        package = "MSstatsPPI"
+        package = "MSstatsBioNet"
     )
 )
 subnetwork <- getSubnetworkFromIndra(input)


### PR DESCRIPTION
# Motivation and Context

After a discussion, MSstatsPPI is too narrow and we decided MSstatsBioNet provides a better name for the purpose of this package, which is the fetch and visualize networks from MS differential abundance data.

## Changes

- Rename MSstatsPPI to MSstatsBioNet
- Remove references to PPIs

## Testing

- All tests pass

## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules