### PR TITLE
ci(pkgdown): Modify branch in which pkgdown is executed

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -2,11 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [devel]
   pull_request:
-    branches: [main, master]
-  release:
-    types: [published]
+    branches: [devel]
   workflow_dispatch:
 
 name: pkgdown


### PR DESCRIPTION
# Motivation and Context

Previously, I integrated pkgdown into MSstatsBioNet to automatically generate a website for MSstatsBioNet, but it triggered on main branch.  We want it to trigger on push to devel.  Also, release is not relevant for us.

## Changes

- Switch main/master to devel in the pkgdown github workflow
- Remove release trigger

## Testing

- Workflow runs in this PR

## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules