### PR TITLE
docs(readme): Add code coverage badge on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MSstatsBioNet
 
+[![Codecov test coverage](https://codecov.io/github/Vitek-Lab/MSstatsBioNet/graph/badge.svg?token=SCPSPMTOEF)](https://codecov.io/github/Vitek-Lab/MSstatsBioNet)
+
 This package provides a suite of functions to query various network databases, 
 filter queries & results, and visualize networks.
 


### PR DESCRIPTION
# Motivation and Context

We would like the code coverage badge to be front of display on the package README.

## Changes

- Add code coverage badge to README

## Testing

Verified badge is present and looks correct on README of remote branch.

## Checklist Before Requesting a Review
- [ ] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules