### PR TITLE
fix(visualizeNetwork): Update visualizeNetwork to only execute when interative() is true

### DIFF
--- a/R/getSubnetworkFromIndra.R
+++ b/R/getSubnetworkFromIndra.R
@@ -14,9 +14,9 @@
 #'     "extdata/groupComparisonModel.csv",
 #'     package = "MSstatsBioNet"
 #' ))
-#' # subnetwork = getSubnetworkFromIndra(input, pvalue_cutoff = 0.05)
-#' # head(subnetwork$nodes)
-#' # head(subnetwork$edges)
+#' subnetwork <- getSubnetworkFromIndra(input, pvalue_cutoff = 0.05)
+#' head(subnetwork$nodes)
+#' head(subnetwork$edges)
 #'
 getSubnetworkFromIndra <- function(input, pvalue_cutoff = NULL) {
     input <- .filterGetSubnetworkFromIndraInput(input, pvalue_cutoff)
@@ -24,10 +24,10 @@ getSubnetworkFromIndra <- function(input, pvalue_cutoff = NULL) {
     nodes <- .constructNodesDataFrame(input)
     edges <- .constructEdgesDataFrame(res, input)
     warning(
-        "NOTICE: This function includes third-party software components 
-        that are licensed under the BSD 2-Clause License. Please ensure to 
-        include the third-party licensing agreements if redistributing this 
-        package or utilizing the results based on this package. 
+        "NOTICE: This function includes third-party software components
+        that are licensed under the BSD 2-Clause License. Please ensure to
+        include the third-party licensing agreements if redistributing this
+        package or utilizing the results based on this package.
         See the LICENSE file for more details."
     )
     return(list(nodes = nodes, edges = edges))

--- a/R/visualizeNetworks.R
+++ b/R/visualizeNetworks.R
@@ -1,4 +1,5 @@
-#' Create visualization of subnetwork in cytoscape
+#' Create visualization of network in Cytoscape Desktop.  Note that the
+#' Cytoscape Desktop app must be open for this function to work.
 #'
 #' @param nodes dataframe of nodes
 #' @param edges dataframe of edges
@@ -16,44 +17,48 @@
 #'     "extdata/groupComparisonModel.csv",
 #'     package = "MSstatsBioNet"
 #' ))
-#' # subnetwork = getSubnetworkFromIndra(input)
-#' # visualizeNetworks(subnetwork$nodes, subnetwork$edges)
+#' subnetwork <- getSubnetworkFromIndra(input)
+#' visualizeNetworks(subnetwork$nodes, subnetwork$edges)
 #'
 #' @return cytoscape visualization of subnetwork
 #'
 #'
 visualizeNetworks <- function(nodes, edges,
-                                pvalue_cutoff = 0.05, logfc_cutoff = 0.5) {
+                              pvalue_cutoff = 0.05, logfc_cutoff = 0.5) {
     # Add additional columns for visualization
     nodes$logFC_color <- nodes$logFC
     nodes$logFC_color[nodes$pvalue > pvalue_cutoff |
         abs(nodes$logFC) < logfc_cutoff] <- 0
 
     # Create network
-    createNetworkFromDataFrames(nodes, edges)
+    if (interactive()) {
+        createNetworkFromDataFrames(nodes, edges)
 
-    # Apply visual style
-    DEFAULT_VISUAL_STYLE <- list(
-        NODE_SHAPE = "ROUNDRECT",
-        NODE_SIZE = 50,
-        NODE_LABEL_FONT_SIZE = 6,
-        NODE_LABEL_POSITION = "center",
-        EDGE_TARGET_ARROW_SHAPE = "Arrow"
-    )
-    VISUAL_STYLE_NAME <- "MSstats-Indra Visual Style"
-
-    VISUAL_STYLE_MAPPINGS <- list(
-        mapVisualProperty("Node Label", "id", "p"),
-        mapVisualProperty(
-            "Node Fill Color", "logFC_color", "c",
-            c(-logfc_cutoff, 0.0, logfc_cutoff),
-            c("#5588DD", "#5588DD", "#D3D3D3", "#DD8855", "#DD8855")
+        # Apply visual style
+        DEFAULT_VISUAL_STYLE <- list(
+            NODE_SHAPE = "ROUNDRECT",
+            NODE_SIZE = 50,
+            NODE_LABEL_FONT_SIZE = 6,
+            NODE_LABEL_POSITION = "center",
+            EDGE_TARGET_ARROW_SHAPE = "Arrow"
         )
-    )
-    createVisualStyle(
-        VISUAL_STYLE_NAME,
-        DEFAULT_VISUAL_STYLE,
-        VISUAL_STYLE_MAPPINGS
-    )
-    setVisualStyle(VISUAL_STYLE_NAME)
+        VISUAL_STYLE_NAME <- "MSstats-Indra Visual Style"
+
+        VISUAL_STYLE_MAPPINGS <- list(
+            mapVisualProperty("Node Label", "id", "p"),
+            mapVisualProperty(
+                "Node Fill Color", "logFC_color", "c",
+                c(-logfc_cutoff, 0.0, logfc_cutoff),
+                c("#5588DD", "#5588DD", "#D3D3D3", "#DD8855", "#DD8855")
+            )
+        )
+        createVisualStyle(
+            VISUAL_STYLE_NAME,
+            DEFAULT_VISUAL_STYLE,
+            VISUAL_STYLE_MAPPINGS
+        )
+        setVisualStyle(VISUAL_STYLE_NAME)
+    } else {
+        warning("Visualization is not available in non-interactive mode.")
+    }
 }

--- a/man/getSubnetworkFromIndra.Rd
+++ b/man/getSubnetworkFromIndra.Rd
@@ -24,8 +24,8 @@ input <- data.table::fread(system.file(
     "extdata/groupComparisonModel.csv",
     package = "MSstatsBioNet"
 ))
-# subnetwork = getSubnetworkFromIndra(input, pvalue_cutoff = 0.05)
-# head(subnetwork$nodes)
-# head(subnetwork$edges)
+subnetwork <- getSubnetworkFromIndra(input, pvalue_cutoff = 0.05)
+head(subnetwork$nodes)
+head(subnetwork$edges)
 
 }

--- a/man/visualizeNetworks.Rd
+++ b/man/visualizeNetworks.Rd
@@ -2,7 +2,8 @@
 % Please edit documentation in R/visualizeNetworks.R
 \name{visualizeNetworks}
 \alias{visualizeNetworks}
-\title{Create visualization of subnetwork in cytoscape}
+\title{Create visualization of network in Cytoscape Desktop.  Note that the
+Cytoscape Desktop app must be open for this function to work.}
 \usage{
 visualizeNetworks(nodes, edges, pvalue_cutoff = 0.05, logfc_cutoff = 0.5)
 }
@@ -21,14 +22,15 @@ proteins. Default is 0.5}
 cytoscape visualization of subnetwork
 }
 \description{
-Create visualization of subnetwork in cytoscape
+Create visualization of network in Cytoscape Desktop.  Note that the
+Cytoscape Desktop app must be open for this function to work.
 }
 \examples{
 input <- data.table::fread(system.file(
     "extdata/groupComparisonModel.csv",
     package = "MSstatsBioNet"
 ))
-# subnetwork = getSubnetworkFromIndra(input)
-# visualizeNetworks(subnetwork$nodes, subnetwork$edges)
+subnetwork <- getSubnetworkFromIndra(input)
+visualizeNetworks(subnetwork$nodes, subnetwork$edges)
 
 }

--- a/tests/testthat/test-getSubnetworkFromIndra.R
+++ b/tests/testthat/test-getSubnetworkFromIndra.R
@@ -5,7 +5,7 @@ test_that("getSubnetworkFromIndra works correctly", {
     local_mocked_bindings(.callIndraCogexApi = function(x) {
         return(readRDS(system.file("extdata/indraResponse.rds", package = "MSstatsBioNet")))
     })
-    subnetwork <- getSubnetworkFromIndra(input)
+    suppressWarnings(subnetwork <- getSubnetworkFromIndra(input))
     expect_equal(nrow(subnetwork$nodes), 7)
     expect_equal(nrow(subnetwork$edges), 2)
 })
@@ -17,7 +17,8 @@ test_that("getSubnetworkFromIndra with pvalue filter works correctly", {
     local_mocked_bindings(.callIndraCogexApi = function(x) {
         return(readRDS(system.file("extdata/indraResponse.rds", package = "MSstatsBioNet")))
     })
-    subnetwork <- getSubnetworkFromIndra(input, pvalue_cutoff = 0.45)
+    suppressWarnings(
+        subnetwork <- getSubnetworkFromIndra(input, pvalue_cutoff = 0.45))
     expect_equal(nrow(subnetwork$nodes), 6)
     expect_equal(nrow(subnetwork$edges), 2)
 })

--- a/tests/testthat/test-visualizeNetworks.R
+++ b/tests/testthat/test-visualizeNetworks.R
@@ -3,6 +3,11 @@ test_that("visualizeNetworks works correctly", {
         package = "MSstatsBioNet"
     ))
 
+    mock_interactive <- mock(TRUE)
+    stub(
+        visualizeNetworks, "interactive",
+        mock_interactive
+    )
     mock_createNetworkFromDataFrames <- mock()
     stub(
         visualizeNetworks, "createNetworkFromDataFrames",
@@ -37,6 +42,11 @@ test_that("visualizeNetworks with p-value and logFC constraints works", {
         package = "MSstatsBioNet"
     ))
 
+    mock_interactive <- mock(TRUE)
+    stub(
+        visualizeNetworks, "interactive",
+        mock_interactive
+    )
     mock_createNetworkFromDataFrames <- mock()
     stub(
         visualizeNetworks, "createNetworkFromDataFrames",

--- a/tests/testthat/test-visualizeNetworks.R
+++ b/tests/testthat/test-visualizeNetworks.R
@@ -82,3 +82,19 @@ test_that("visualizeNetworks with p-value and logFC constraints works", {
     )
     expect_equal(nodes[input$nodes$id == "BRD4_HUMAN", ]$logFC_color, 0)
 })
+
+test_that("visualizeNetworks returns warning for non-interactive calls", {
+    input <- readRDS(system.file("extdata/subnetwork.rds",
+                                 package = "MSstatsBioNet"
+    ))
+    
+    mock_interactive <- mock(FALSE)
+    stub(
+        visualizeNetworks, "interactive",
+        mock_interactive
+    )
+    
+    expect_warning(visualizeNetworks(input$nodes, input$edges,
+                                    pvalue_cutoff = 0.01, logfc_cutoff = 2.5
+    ))
+})

--- a/vignettes/MSstatsBioNet.Rmd
+++ b/vignettes/MSstatsBioNet.Rmd
@@ -30,14 +30,18 @@ networks. The package is designed to be used in conjunction with the
 
 ```{r}
 library(MSstatsConvert)
-input = system.file("tinytest/raw_data/Metamorpheus/AllQuantifiedPeaks.tsv", 
-                                package = "MSstatsConvert")
-input = data.table::fread(input)
-annot = system.file("tinytest/raw_data/Metamorpheus/Annotation.tsv", 
-                                package = "MSstatsConvert")
-annot = data.table::fread(annot)
-msstats_imported = MetamorpheusToMSstatsFormat(input, annotation = annot, 
-                                               use_log_file = FALSE)
+input <- system.file("tinytest/raw_data/Metamorpheus/AllQuantifiedPeaks.tsv",
+    package = "MSstatsConvert"
+)
+input <- data.table::fread(input)
+annot <- system.file("tinytest/raw_data/Metamorpheus/Annotation.tsv",
+    package = "MSstatsConvert"
+)
+annot <- data.table::fread(annot)
+msstats_imported <- MetamorpheusToMSstatsFormat(input,
+    annotation = annot,
+    use_log_file = FALSE
+)
 head(msstats_imported)
 ```
 
@@ -45,10 +49,12 @@ head(msstats_imported)
 
 ```{r}
 library(MSstats)
-QuantData = dataProcess(msstats_imported, use_log_file = FALSE)
-groupComparisonResult = groupComparison(contrast.matrix="pairwise", 
-                                        data=QuantData, 
-                                        use_log_file = FALSE)
+QuantData <- dataProcess(msstats_imported, use_log_file = FALSE)
+groupComparisonResult <- groupComparison(
+    contrast.matrix = "pairwise",
+    data = QuantData,
+    use_log_file = FALSE
+)
 ```
 
 # MSstatsBioNet Analysis
@@ -65,7 +71,7 @@ In the future, this uniprot client will be added as a separate function to allow
 users to perform this conversion in R in a streamlined way.
 
 ```{r}
-uniprot_to_hgnc_mapping = c(
+uniprot_to_hgnc_mapping <- c(
     "B9A064" = "38476",
     "O00391" = "9756",
     "O14818" = "9536",
@@ -74,7 +80,7 @@ uniprot_to_hgnc_mapping = c(
     "P16050" = "11390",
     "P84243" = "4765"
 )
-groupComparisonResult$ComparisonResult$HgncId = uniprot_to_hgnc_mapping[
+groupComparisonResult$ComparisonResult$HgncId <- uniprot_to_hgnc_mapping[
     groupComparisonResult$ComparisonResult$Protein
 ]
 ```
@@ -83,19 +89,21 @@ groupComparisonResult$ComparisonResult$HgncId = uniprot_to_hgnc_mapping[
 
 The package provides a function `getSubnetworkFromIndra` that retrieves a
 subnetwork of proteins from the INDRA database based on differential abundance
-analysis results.  The function `visualizeNetworks` then takes the output
-of `getSubnetworkFromIndra` and visualizes the subnetwork.
+analysis results.  
 
-```{r proteinNetworkDiscovery, eval=FALSE}
-
-subnetwork = getSubnetworkFromIndra(groupComparisonResult$ComparisonResult)
+```{r}
+subnetwork <- getSubnetworkFromIndra(groupComparisonResult$ComparisonResult)
 ```
+
 This package is distributed under the [Artistic-2.0](https://opensource.org/licenses/Artistic-2.0) license.  However, its dependencies may have different licenses.  In this example, getSubnetworkFromIndra depends on INDRA, which is distributed under the [BSD 2-Clause](https://opensource.org/license/bsd-2-clause) license.  Furthermore, INDRA's knowledge sources may have different licenses for commercial applications.  Please refer to the [INDRA README](https://github.com/sorgerlab/indra?tab=readme-ov-file#indra-modules) for more information on its knowledge sources and their associated licenses.
 
 
 ## Visualize Networks
 
-```{r visualizeNetwork, eval=FALSE}
+The function `visualizeNetworks` then takes the output of 
+`getSubnetworkFromIndra` and visualizes the subnetwork.
+
+```{r}
 visualizeNetworks(subnetwork$nodes, subnetwork$edges)
 ```
 


### PR DESCRIPTION
# Motivation and Context

Based on this [issue](https://github.com/Bioconductor/Contributions/issues/3500), bioconductor suggested to use the `interactive()` command to help determine if a user is executing a function or if an automated build is executing a function.  In the case of visualizeNetwork, using `interactive()` is justifiable since it requires Cytoscape desktop to be open and there is no way Cytoscape desktop can be open during a build.  However, I'm not adding it for `getSubnetworkFromIndra` because there are use cases where calling INDRA API is justifiable from an automation perspective (plus servers should have Internet access).

## Changes

- Added `interactive()` flag to the `visualizeNetwork` function
- Styled using `styler::style_pkg(transformers = styler::tidyverse_style(indent_by = 4))`

## Testing

- Existing unit tests pass.  It required mocking the `interactive()` command to TRUE for unit tests

## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules