### PR TITLE
docs(getSubnetworkFromIndra): Switch MSstats as dependency, adjust link to groupComparison

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,8 @@ Imports:
     RCy3,
     httr,
     jsonlite,
-    r2r
+    r2r,
+    MSstats
 Suggests: 
     data.table,
     BiocStyle,
@@ -28,7 +29,6 @@ Suggests:
     rmarkdown,
     testthat (>= 3.0.0),
     mockery,
-    MSstats,
     MSstatsConvert
 VignetteBuilder: knitr
 biocViews: ImmunoOncology, MassSpectrometry, Proteomics, Software, 

--- a/R/getSubnetworkFromIndra.R
+++ b/R/getSubnetworkFromIndra.R
@@ -3,14 +3,14 @@
 #' Using differential abundance results from MSstats, this function retrieves
 #' a subnetwork of protein interactions from INDRA database.
 #'
-#' @param input output of groupComparison function's comparisionResult table,
-#' which contains a list of proteins and their corresponding p-values, logFCs,
-#' along with additional HGNC ID and HGNC name columns
+#' @param input output of \code{\link[MSstats]{groupComparison}} function's 
+#' comparisionResult table, which contains a list of proteins and their 
+#' corresponding p-values, logFCs, along with additional HGNC ID and HGNC 
+#' name columns
 #' @param pvalueCutoff p-value cutoff for filtering. Default is NULL, i.e. no
 #' filtering
 #'
 #' @return list of 2 data.frames, nodes and edges
-#' @seealso \code{\link[MSstats]{groupComparison}}
 #'
 #' @export
 #'

--- a/man/getSubnetworkFromIndra.Rd
+++ b/man/getSubnetworkFromIndra.Rd
@@ -7,9 +7,10 @@
 getSubnetworkFromIndra(input, pvalueCutoff = NULL)
 }
 \arguments{
-\item{input}{output of groupComparison function's comparisionResult table, 
-which contains a list of proteins and their corresponding p-values, logFCs,
-along with additional HGNC ID and HGNC name columns}
+\item{input}{output of \code{\link[MSstats]{groupComparison}} function's 
+comparisionResult table, which contains a list of proteins and their 
+corresponding p-values, logFCs, along with additional HGNC ID and HGNC 
+name columns}
 
 \item{pvalueCutoff}{p-value cutoff for filtering. Default is NULL, i.e. no
 filtering}
@@ -30,7 +31,4 @@ subnetwork <- getSubnetworkFromIndra(input, pvalueCutoff = 0.05)
 head(subnetwork$nodes)
 head(subnetwork$edges)
 
-}
-\seealso{
-\code{\link[MSstats]{groupComparison}}
 }

--- a/man/visualizeNetworks.Rd
+++ b/man/visualizeNetworks.Rd
@@ -7,11 +7,11 @@
 visualizeNetworks(nodes, edges, pvalueCutoff = 0.05, logfcCutoff = 0.5)
 }
 \arguments{
-\item{nodes}{dataframe of nodes consisting of columns 
+\item{nodes}{dataframe of nodes consisting of columns
 id (chararacter), pvalue (number), logFC (number)}
 
 \item{edges}{dataframe of edges consisting of columns
-source (character), target (character), interaction (character), 
+source (character), target (character), interaction (character),
 evidenceCount (number), evidenceLink (character)}
 
 \item{pvalueCutoff}{p-value cutoff for coloring significant proteins.
@@ -24,8 +24,8 @@ proteins. Default is 0.5}
 cytoscape visualization of subnetwork
 }
 \description{
-Use results from INDRA to generate a visualization of the a network on 
-Cytoscape Desktop.  Note that the Cytoscape Desktop app must be open for 
+Use results from INDRA to generate a visualization of the a network on
+Cytoscape Desktop.  Note that the Cytoscape Desktop app must be open for
 this function to work.
 }
 \examples{


### PR DESCRIPTION
### **User description**
## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Ran styler::style_pkg(transformers = styler::tidyverse_style(indent_by = 4))
- [x] Ran devtools::document()


___

### **PR Type**
documentation, enhancement


___

### **Description**
- Updated the `DESCRIPTION` file to move `MSstats` from `Suggests` to `Imports`, ensuring it is a required dependency.
- Enhanced the documentation in `R/getSubnetworkFromIndra.R` and `man/getSubnetworkFromIndra.Rd` by linking to the `groupComparison` function from `MSstats`.
- Removed unnecessary `seealso` section from `man/getSubnetworkFromIndra.Rd`.
- Fixed minor formatting issues in the `man/visualizeNetworks.Rd` documentation.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DESCRIPTION</strong><dd><code>Update package dependencies in DESCRIPTION file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

DESCRIPTION

<li>Added <code>MSstats</code> to the <code>Imports</code> section.<br> <li> Removed <code>MSstats</code> from the <code>Suggests</code> section.<br>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstatsBioNet/pull/22/files#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231c">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>getSubnetworkFromIndra.R</strong><dd><code>Enhance documentation with proper function linking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

R/getSubnetworkFromIndra.R

<li>Updated documentation to use <code>\code{\link[MSstats]{groupComparison}}</code> <br>for linking.<br>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstatsBioNet/pull/22/files#diff-69b9efe42411109c5e882cf537ec1ebd13578cd07282d80f2353c780e9aa2564">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>getSubnetworkFromIndra.Rd</strong><dd><code>Improve manual with function linking and cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

man/getSubnetworkFromIndra.Rd

<li>Updated documentation to include <br><code>\code{\link[MSstats]{groupComparison}}</code>.<br> <li> Removed <code>seealso</code> section.<br>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstatsBioNet/pull/22/files#diff-98e457b5d3690333666d2861670d7e7e1a1bee271d2203f368b105fe4c70103b">+4/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>visualizeNetworks.Rd</strong><dd><code>Correct formatting in visualizeNetworks documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

man/visualizeNetworks.Rd

- Fixed minor formatting issues in the documentation.



</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstatsBioNet/pull/22/files#diff-a124a49795cfba14fc2fea53832c27351684483ec36a62090efb2d4e63e0d16e">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information