### PR TITLE
Fix edge case where source id is second element in complex listing

### DIFF
--- a/R/getPathwaysFromIndra.R
+++ b/R/getPathwaysFromIndra.R
@@ -50,7 +50,7 @@ getPathwaysFromIndra <- function(annotated_df, main_target = 'MEN1_HUMAN', targe
     } else {
         stop("Invalid target type.")
     }
-    url = paste('https://db.indra.bio/statements/from_agents?source_idect=',
+    url = paste('https://db.indra.bio/statements/from_agents?subject=',
                 source_id, namespace, sep = "")
     response <- GET(url)
     z = content(response)

--- a/R/getPathwaysFromIndra.R
+++ b/R/getPathwaysFromIndra.R
@@ -50,7 +50,7 @@ getPathwaysFromIndra <- function(annotated_df, main_target = 'MEN1_HUMAN', targe
     } else {
         stop("Invalid target type.")
     }
-    url = paste('https://db.indra.bio/statements/from_agents?subject=',
+    url = paste('https://db.indra.bio/statements/from_agents?source_idect=',
                 source_id, namespace, sep = "")
     response <- GET(url)
     z = content(response)
@@ -66,23 +66,19 @@ getPathwaysFromIndra <- function(annotated_df, main_target = 'MEN1_HUMAN', targe
         if (edge$type == "Complex") {
             if (length(edge$members) == 2) {
                 if (identical(edge$members[[1]]$db_refs[[id_field]], source_id)) {
-                    subj = source_id
                     obj = edge$members[[2]]$db_refs$HGNC
                     namespaces = names(edge$members[[2]]$db_refs)
                 } else {
-                    subj = edge$members[[2]]$db_refs$HGNC
-                    obj = source_id
+                    obj = edge$members[[1]]$db_refs$HGNC
                     namespaces = names(edge$members[[1]]$db_refs)
                 }
             } else {
                 namespaces = c()
             }
         } else if (edge$type == "Phosphorylation") {
-            subj = source_id
             obj = edge$sub$db_refs$HGNC
             namespaces = names(edge$sub$db_refs)
         } else {
-            subj = source_id
             obj = edge$obj$db_refs$HGNC
             namespaces = names(edge$obj$db_refs)
         }
@@ -94,7 +90,7 @@ getPathwaysFromIndra <- function(annotated_df, main_target = 'MEN1_HUMAN', targe
             next
         }
         
-        key <- paste(subj, obj, sep = "_")
+        key <- paste(source_id, obj, sep = "_")
         
         if (key %in% keys(edgeToMetadataMapping)) {
             edgeToMetadataMapping[[key]]$data$evidence_count <-
@@ -109,7 +105,7 @@ getPathwaysFromIndra <- function(annotated_df, main_target = 'MEN1_HUMAN', targe
             edgeToMetadataMapping[[key]]$data$evidence_count <-
                 z$evidence_counts[[index]]
             edgeToMetadataMapping[[key]]$data$stmt_type <- c(edge$type)
-            edgeToMetadataMapping[[key]]$source_id <- subj
+            edgeToMetadataMapping[[key]]$source_id <- source_id
             edgeToMetadataMapping[[key]]$target_id <- obj
             edgeToMetadataMapping[[key]] <- MSstatsBioNet:::.addAdditionalMetadataToIndraEdge(
                 edgeToMetadataMapping[[key]], annotated_df, namespace


### PR DESCRIPTION

### **PR Type**
Bug fix


___

### **Description**
- Correct API URL parameter name.

- Use `source_id` instead of `subj` throughout.

- Update edge key generation with `source_id`.

- Remove redundant `subj` assignments.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>getPathwaysFromIndra.R</strong><dd><code>Unify source_id usage and fix API URL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

R/getPathwaysFromIndra.R

<li>Corrected URL parameter from <code>subject</code> to <code>source_idect</code><br> <li> Removed redundant <code>subj</code> assignments in branches<br> <li> Unified key generation using <code>source_id</code> and <code>obj</code><br> <li> Updated metadata mapping to use <code>source_id</code>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstatsBioNet/pull/46/files#diff-568d812d105f0293b449b01f729f293a823ecf01c2755733d0e2d178540ce0d9">+4/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>