### PR TITLE
ci(bioc): Add workflow to resolve bioc version conflicts

### DIFF
--- a/.github/workflows/push-bioconductor-devel.yml
+++ b/.github/workflows/push-bioconductor-devel.yml
@@ -36,4 +36,10 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git push upstream devel
+          if git push upstream devel; then
+            echo "Successfully pushed to Bioconductor"
+          else
+            echo "Push failed - likely due to version bumps in Bioconductor"
+            echo "Run the --Sync from Bioconductor-- workflow to resolve this"
+            exit 1  
+          fi

--- a/.github/workflows/push-bioconductor-devel.yml
+++ b/.github/workflows/push-bioconductor-devel.yml
@@ -40,6 +40,6 @@ jobs:
             echo "Successfully pushed to Bioconductor"
           else
             echo "Push failed - likely due to version bumps in Bioconductor"
-            echo "Run the --Sync from Bioconductor-- workflow to resolve this"
+            echo "Run the Sync from Bioconductor workflow to resolve this"
             exit 1  
           fi

--- a/.github/workflows/sync-bioconductor.yml
+++ b/.github/workflows/sync-bioconductor.yml
@@ -17,6 +17,12 @@ jobs:
       with:
         ssh-private-key: ${{ secrets.BIOC_SSH_PRIVATE_KEY }}
         
+    - name: Add SSH host key
+        run: |
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          ssh-keyscan -H git.bioconductor.org >> ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
     - name: Configure git
       run: |
         git config user.name "github-actions[bot]"
@@ -24,6 +30,7 @@ jobs:
         
     - name: Sync with Bioconductor
       run: |
+        git remote remove upstream || true
         git remote add upstream git@git.bioconductor.org:packages/MSstatsBioNet.git
         git fetch upstream
         

--- a/.github/workflows/sync-bioconductor.yml
+++ b/.github/workflows/sync-bioconductor.yml
@@ -1,0 +1,47 @@
+name: Sync from Bioconductor
+on:
+  workflow_dispatch:     # Allow manual trigger
+
+jobs:
+  sync-from-bioc:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        fetch-depth: 0  # Need full history for rebase
+        
+    - name: Setup SSH key
+      uses: webfactory/ssh-agent@v0.9.0
+      with:
+        ssh-private-key: ${{ secrets.BIOC_SSH_PRIVATE_KEY }}
+        
+    - name: Configure git
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        
+    - name: Sync with Bioconductor
+      run: |
+        git remote add upstream git@git.bioconductor.org:packages/MSstatsBioNet.git
+        git fetch upstream
+        
+        # Check if Bioconductor has changes we don't have
+        if ! git merge-base --is-ancestor upstream/devel HEAD; then
+          echo "Bioconductor has new changes - rebasing our branch"
+          
+          # Show what they changed
+          echo "New commits from Bioconductor:"
+          git log --oneline HEAD..upstream/devel
+          
+          # Rebase our commits on top of theirs
+          git rebase upstream/devel -X theirs
+          
+          # Push the rebased branch back to GitHub
+          git push origin devel --force-with-lease
+          
+          echo "Successfully synced with Bioconductor"
+        else
+          echo "Already up to date with Bioconductor"
+        fi

--- a/.github/workflows/sync-bioconductor.yml
+++ b/.github/workflows/sync-bioconductor.yml
@@ -18,10 +18,10 @@ jobs:
         ssh-private-key: ${{ secrets.BIOC_SSH_PRIVATE_KEY }}
         
     - name: Add SSH host key
-        run: |
-          mkdir -p ~/.ssh && chmod 700 ~/.ssh
-          ssh-keyscan -H git.bioconductor.org >> ~/.ssh/known_hosts
-          chmod 644 ~/.ssh/known_hosts
+      run: |
+        mkdir -p ~/.ssh && chmod 700 ~/.ssh
+        ssh-keyscan -H git.bioconductor.org >> ~/.ssh/known_hosts
+        chmod 644 ~/.ssh/known_hosts
 
     - name: Configure git
       run: |

--- a/.github/workflows/sync-bioconductor.yml
+++ b/.github/workflows/sync-bioconductor.yml
@@ -6,49 +6,48 @@ jobs:
   sync-from-bioc:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        fetch-depth: 0  # Need full history for rebase
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0  # Need full history for rebase
+      - name: Setup SSH key
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.BIOC_SSH_PRIVATE_KEY }}
+      - name: Add SSH host key
+        run: |
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          ssh-keyscan -H git.bioconductor.org >> ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Add Bioconductor remote
+        run: |
+          git remote remove upstream || true
+          git remote add upstream git@git.bioconductor.org:packages/MSstatsBioNet.git
+      - name: Sync with Bioconductor
+        run: |
+          set -euo pipefail
+          git fetch upstream
         
-    - name: Setup SSH key
-      uses: webfactory/ssh-agent@v0.9.0
-      with:
-        ssh-private-key: ${{ secrets.BIOC_SSH_PRIVATE_KEY }}
-        
-    - name: Add SSH host key
-      run: |
-        mkdir -p ~/.ssh && chmod 700 ~/.ssh
-        ssh-keyscan -H git.bioconductor.org >> ~/.ssh/known_hosts
-        chmod 644 ~/.ssh/known_hosts
-
-    - name: Configure git
-      run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
-        
-    - name: Sync with Bioconductor
-      run: |
-        git remote remove upstream || true
-        git remote add upstream git@git.bioconductor.org:packages/MSstatsBioNet.git
-        git fetch upstream
-        
-        # Check if Bioconductor has changes we don't have
-        if ! git merge-base --is-ancestor upstream/devel HEAD; then
-          echo "Bioconductor has new changes - rebasing our branch"
+          # Check if Bioconductor has changes we don't have
+          if ! git merge-base --is-ancestor upstream/devel HEAD; then
+            echo "Bioconductor has new changes - rebasing our branch"
           
-          # Show what they changed
-          echo "New commits from Bioconductor:"
-          git log --oneline HEAD..upstream/devel
+            # Show what they changed
+            echo "New commits from Bioconductor:"
+            git log --oneline HEAD..upstream/devel
           
-          # Rebase our commits on top of theirs
-          git rebase upstream/devel -X theirs
+            # Rebase our commits on top of theirs
+            git rebase upstream/devel -X theirs
           
-          # Push the rebased branch back to GitHub
-          git push origin devel --force-with-lease
+            # Push the rebased branch back to GitHub
+            git push origin devel --force-with-lease
           
-          echo "Successfully synced with Bioconductor"
-        else
-          echo "Already up to date with Bioconductor"
-        fi
+            echo "Successfully synced with Bioconductor"
+          else
+            echo "Already up to date with Bioconductor"
+          fi


### PR DESCRIPTION
# Motivation and Context

Adding a manual workflow trigger in case there are version conflicts.  I would only consider this piece to be manual because it was a git push --force-with-lease, and I'd rather not deal with any cyclic behavior from automation.  It's also a dangerous operation.

## Changes

- Add a manual workflow trigger for version conflicts.

## Testing

Will test when there's our first version conflict.

## Checklist Before Requesting a Review
- [ ] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Ran styler::style_pkg(transformers = styler::tidyverse_style(indent_by = 4))
- [ ] Ran devtools::document()


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new workflow to manually synchronize the repository with the Bioconductor upstream branch, helping keep local changes up to date.
* **Chores**
  * Improved error handling and messaging for the Bioconductor push workflow, providing clearer instructions and guidance in case of push failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->