### PR TITLE
remove collapsing by interaction type

### DIFF
--- a/R/utils_getSubnetworkFromIndra.R
+++ b/R/utils_getSubnetworkFromIndra.R
@@ -183,17 +183,11 @@
     edgeToMetadataMapping <- hashmap()
 
     for (edge in res) {
-        key <- paste(edge$source_id, edge$target_id, sep = "_")
+        key <- paste(edge$source_id, edge$target_id, edge$data$stmt_type, sep = "_")
         if (key %in% keys(edgeToMetadataMapping)) {
             edgeToMetadataMapping[[key]]$data$evidence_count <-
                 edgeToMetadataMapping[[key]]$data$evidence_count +
                 edge$data$evidence_count
-            edgeToMetadataMapping[[key]]$data$stmt_type <- unique(c(
-                edgeToMetadataMapping[[key]]$data$stmt_type,
-                edge$data$stmt_type))
-            edgeToMetadataMapping[[key]]$data$stmt_type <- unique(c(
-                edgeToMetadataMapping[[key]]$data$stmt_type,
-                edge$data$stmt_type))
             edgeToMetadataMapping[[key]]$data$paper_count <- 
                 edgeToMetadataMapping[[key]]$data$paper_count + 1
         } else {
@@ -201,12 +195,6 @@
             edge$data$paper_count <- 1
             edgeToMetadataMapping[[key]] <- edge
         }
-    }
-    
-    for (key in keys(edgeToMetadataMapping)) {
-        edgeToMetadataMapping[[key]]$data$stmt_type <-
-            paste(unique(edgeToMetadataMapping[[key]]$data$stmt_type), 
-                  collapse = ", ")
     }
 
     return(edgeToMetadataMapping)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of duplicate edges by ensuring edges with different statement types are no longer merged together. Each edge now retains its original statement type, resulting in more accurate edge representation in subnetwork outputs. Evidence and paper counts are still aggregated for truly identical edges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

### **PR Type**
Bug fix


___

### **Description**
- Include `stmt_type` in collapse key

- Remove redundant `stmt_type` aggregation

- Only collapse edges with identical statement types


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils_getSubnetworkFromIndra.R</strong><dd><code>Differentiate edges by statement type in key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

R/utils_getSubnetworkFromIndra.R

<ul><li>Key now includes <code>stmt_type</code> to differentiate edges<br> <li> Deleted loops aggregating <code>stmt_type</code> values<br> <li> Maintains separate entries per statement type</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstatsBioNet/pull/51/files#diff-fa2a69c05887ee5c610e5d06f284de1d083ad342e76535fa9b0001e136653572">+1/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

