### PR TITLE
refactor(getSubnetworkFromIndra): Switch column from pvalue to adj.pvalue for nodes table

### DIFF
--- a/R/utils_getSubnetworkFromIndra.R
+++ b/R/utils_getSubnetworkFromIndra.R
@@ -261,7 +261,7 @@
     nodes <- data.frame(
         id = input$Protein,
         logFC = input$log2FC,
-        pvalue = input$adj.pvalue,
+        adj.pvalue = input$adj.pvalue,
         hgncName = if ("HgncName" %in% colnames(input) && is.character(input$HgncName)) input$HgncName else NA,
         stringsAsFactors = FALSE
     )


### PR DESCRIPTION

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the column name for adjusted p-values in the output data to ensure consistency with the input data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

### **PR Type**
Bug fix


___

### **Description**
- Rename nodes column to adj.pvalue


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils_getSubnetworkFromIndra.R</strong><dd><code>Rename nodes column to adj.pvalue</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

R/utils_getSubnetworkFromIndra.R

<ul><li>Renamed data.frame column from <code>pvalue</code> to <code>adj.pvalue</code><br> <li> Updated <code>.constructNodesDataFrame</code> to use adjusted p-value field</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstatsBioNet/pull/52/files#diff-fa2a69c05887ee5c610e5d06f284de1d083ad342e76535fa9b0001e136653572">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

