### PR TITLE
feature(visualizeNetworksWithHTML): Add INDRA link into javascript visualization

### DIFF
--- a/R/visualizeNetworksWithHTML.R
+++ b/R/visualizeNetworksWithHTML.R
@@ -264,7 +264,7 @@ createEdgeElements <- function(edges) {
                             "', interaction: '", row$interaction,
                             "', edge_type: '", row$edge_type,
                             "', category: '", row$category,
-                            "', evidenceLink: '", row$evidenceLink,
+                            "', evidenceLink: '", gsub("(['\\\\])", "\\\\\\1", ifelse(is.na(row$evidenceLink), "", row$evidenceLink)),
                             "', color: '", style$color,
                             "', line_style: '", style$style,
                             "', arrow_shape: '", style$arrow,

--- a/R/visualizeNetworksWithHTML.R
+++ b/R/visualizeNetworksWithHTML.R
@@ -257,6 +257,11 @@ createEdgeElements <- function(edges) {
         # Get styling for this edge
         style <- getEdgeStyle(row$interaction, row$category, row$edge_type)
         
+        # Sanitize optional evidenceLink
+        evidence_link <- if ("evidenceLink" %in% names(row)) row$evidenceLink else NA_character_
+        evidence_link <- ifelse(is.na(evidence_link) | evidence_link == "NA", "", evidence_link)
+        evidence_link <- escape_js_string(evidence_link)
+        
         # Create edge data with styling information
         edge_data <- paste0("{ data: { source: '", row$source, 
                             "', target: '", row$target, 
@@ -264,7 +269,7 @@ createEdgeElements <- function(edges) {
                             "', interaction: '", row$interaction,
                             "', edge_type: '", row$edge_type,
                             "', category: '", row$category,
-                            "', evidenceLink: '", gsub("(['\\\\])", "\\\\\\1", ifelse(is.na(row$evidenceLink), "", row$evidenceLink)),
+                            "', evidenceLink: '", evidence_link,
                             "', color: '", style$color,
                             "', line_style: '", style$style,
                             "', arrow_shape: '", style$arrow,
@@ -274,6 +279,17 @@ createEdgeElements <- function(edges) {
     }
     
     return(edge_elements)
+}
+
+# Helper to safely embed strings into JS single-quoted literals
+escape_js_string <- function(x) {
+    if (is.null(x)) return("")
+    x <- as.character(x)
+    x <- gsub("\\\\", "\\\\\\\\", x)  # backslashes
+    x <- gsub("'", "\\\\'", x)        # single quotes
+    x <- gsub("\r", "\\\\r", x)
+    x <- gsub("\n", "\\\\n", x)
+    x
 }
 
 #' Generate Cytoscape visualization configuration

--- a/R/visualizeNetworksWithHTML.R
+++ b/R/visualizeNetworksWithHTML.R
@@ -264,6 +264,7 @@ createEdgeElements <- function(edges) {
                             "', interaction: '", row$interaction,
                             "', edge_type: '", row$edge_type,
                             "', category: '", row$category,
+                            "', evidenceLink: '", row$evidenceLink,
                             "', color: '", style$color,
                             "', line_style: '", style$style,
                             "', arrow_shape: '", style$arrow,


### PR DESCRIPTION
### **User description**
# Motivation and Context

Please include relevant motivation and context of the problem along with a short summary of the solution.

## Changes

Please provide a detailed bullet point list of your changes.

- 

## Testing

Please describe any unit tests you added or modified to verify your changes.

## Checklist Before Requesting a Review
- [ ] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Ran styler::style_pkg(transformers = styler::tidyverse_style(indent_by = 4))
- [ ] Ran devtools::document()


___

### **PR Type**
Enhancement


___

### **Description**
- Add `evidenceLink` to edge data

- Enable opening INDRA evidence pages


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Rfn["R/visualizeNetworksWithHTML.R"]
  EdgeFn["createEdgeElements()"]
  EdgeData["Edge JSON data includes evidenceLink"]
  INDRA["Open INDRA evidence pages"]

  Rfn -- modifies --> EdgeFn
  EdgeFn -- adds field --> EdgeData
  EdgeData -- enables --> INDRA
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>visualizeNetworksWithHTML.R</strong><dd><code>Add evidenceLink field to edge JSON payload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

R/visualizeNetworksWithHTML.R

<ul><li>Extend edge JSON with <code>evidenceLink</code>.<br> <li> Propagate <code>row$evidenceLink</code> into Cytoscape data.<br> <li> Prepare edges for opening INDRA URLs.</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstatsBioNet/pull/57/files#diff-1a65dd3c3c8e63963a80ce1a2bd02dd366c53d30d0f547c747e3d4bd009c9eed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Network visualizations now include an evidence link for each edge, enabling templates or displays to reference supporting evidence.
* **Bug Fixes / Behavior Changes**
  * Empty or missing evidence is now represented as an empty value (not “NA”).
  * Evidence links are safely sanitized when embedded to prevent formatting issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->