### PR TITLE
feature(visualizeNetworkWithHTML): add edge clicking to URL for regular HTML

### DIFF
--- a/R/utils_getSubnetworkFromIndra.R
+++ b/R/utils_getSubnetworkFromIndra.R
@@ -253,10 +253,10 @@
         } else {
             edge$site = NA_character_
         }
-        edge <- .addAdditionalMetadataToIndraEdge(edge, input)
-        edge$data$paper_count <- 1 # TODO: fix paper count
         if (!key %in% keys(edgeToMetadataMapping) || 
             edge$data$evidence_count > edgeToMetadataMapping[[key]]$data$evidence_count) {
+            edge <- .addAdditionalMetadataToIndraEdge(edge, input)
+            edge$data$paper_count <- 1 # TODO: fix paper count
             edgeToMetadataMapping[[key]] <- edge
         }
     }

--- a/R/utils_getSubnetworkFromIndra.R
+++ b/R/utils_getSubnetworkFromIndra.R
@@ -306,7 +306,7 @@
             query(res, x)$data$source_counts
         }, ""),
         stmt_hash = vapply(keys(res), function(x) {
-            query(res, x)$data$stmt_hash
+            as.character(query(res, x)$data$stmt_hash)
         }, ""),
         stringsAsFactors = FALSE
     )

--- a/R/utils_getSubnetworkFromIndra.R
+++ b/R/utils_getSubnetworkFromIndra.R
@@ -305,6 +305,9 @@
         sourceCounts = vapply(keys(res), function(x) {
             query(res, x)$data$source_counts
         }, ""),
+        stmt_hash = vapply(keys(res), function(x) {
+            query(res, x)$data$stmt_hash
+        }, ""),
         stringsAsFactors = FALSE
     )
     # add correlation - maybe create a separate function

--- a/R/utils_getSubnetworkFromIndra.R
+++ b/R/utils_getSubnetworkFromIndra.R
@@ -253,15 +253,10 @@
         } else {
             edge$site = NA_character_
         }
-        if (key %in% keys(edgeToMetadataMapping)) {
-            edgeToMetadataMapping[[key]]$data$evidence_count <-
-                edgeToMetadataMapping[[key]]$data$evidence_count +
-                edge$data$evidence_count
-            edgeToMetadataMapping[[key]]$data$paper_count <- 
-                edgeToMetadataMapping[[key]]$data$paper_count + 1
-        } else {
-            edge <- .addAdditionalMetadataToIndraEdge(edge, input)
-            edge$data$paper_count <- 1
+        edge <- .addAdditionalMetadataToIndraEdge(edge, input)
+        edge$data$paper_count <- 1 # TODO: fix paper count
+        if (!key %in% keys(edgeToMetadataMapping) || 
+            edge$data$evidence_count > edgeToMetadataMapping[[key]]$data$evidence_count) {
             edgeToMetadataMapping[[key]] <- edge
         }
     }

--- a/R/visualizeNetworksWithHTML.R
+++ b/R/visualizeNetworksWithHTML.R
@@ -829,6 +829,23 @@ exportCytoscapeToHTML <- function(config,
     <script src="https://cdnjs.cloudflare.com/ajax/libs/graphlib/2.1.8/graphlib.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/dagre/0.8.5/dagre.min.js"></script>
     <script src="https://unpkg.com/cytoscape-dagre@2.3.0/cytoscape-dagre.js"></script>
+    <script>
+        function openLinkInNewTab(url) {
+            try {
+                if (!url || typeof url !== "string") return;
+                url = url.trim();
+                if (!url || url === "NA" || url === "") return;
+                if (!/^https?:\\/\\//i.test(url)) {
+                    console.warn("Blocked non-http(s) URL:", url);
+                    return;
+                }
+                var win = window.open(url, "_blank", "noopener,noreferrer");
+                if (win) { win.opener = null; }
+            } catch (err) {
+                console.error("Error opening link:", err);
+            }
+        }
+    </script>
     
     <style>
         body {
@@ -1102,6 +1119,19 @@ exportCytoscapeToHTML <- function(config,
     invisible(normalizePath(filename))
 }
 
+#' @noRd
+createEdgeClickHandler <- function() {
+    list(
+        edge_click = "function(evt) {
+            var edge = evt.target;
+            var evidenceLink = edge.data('evidenceLink');
+            if (evidenceLink && evidenceLink !== '' && evidenceLink !== 'NA') {
+                openLinkInNewTab(evidenceLink);
+            }
+        }"
+    )
+}
+
 #' Export network data with Cytoscape visualization
 #' 
 #' Convenience function that takes nodes and edges data directly and creates
@@ -1119,6 +1149,8 @@ exportNetworkToHTML <- function(nodes, edges,
                                 displayLabelType = "id",
                                 nodeFontSize = 12,
                                 ...) {
+    
+    event_handlers <- createEdgeClickHandler()
     
     # Generate configuration
     config <- generateCytoscapeConfig(nodes, edges, display_label_type = displayLabelType, node_font_size = nodeFontSize)
@@ -1141,8 +1173,16 @@ previewNetworkInBrowser <- function(nodes, edges,
                                     nodeFontSize = 12,
                                     ...) {
     
+    event_handlers <- createEdgeClickHandler()
+    
     # Generate configuration
-    config <- generateCytoscapeConfig(nodes, edges, display_label_type = displayLabelType, node_font_size = nodeFontSize)
+    config <- generateCytoscapeConfig(
+        nodes, 
+        edges, 
+        display_label_type = displayLabelType, 
+        node_font_size = nodeFontSize,
+        event_handlers = event_handlers
+    )
     
     # Create temporary filename
     temp_file <- tempfile(fileext = ".html")

--- a/R/visualizeNetworksWithHTML.R
+++ b/R/visualizeNetworksWithHTML.R
@@ -1153,7 +1153,13 @@ exportNetworkToHTML <- function(nodes, edges,
     event_handlers <- createEdgeClickHandler()
     
     # Generate configuration
-    config <- generateCytoscapeConfig(nodes, edges, display_label_type = displayLabelType, node_font_size = nodeFontSize)
+    config <- generateCytoscapeConfig(
+        nodes, 
+        edges, 
+        display_label_type = displayLabelType, 
+        node_font_size = nodeFontSize,
+        event_handlers = event_handlers
+    )
     
     # Export to HTML
     exportCytoscapeToHTML(config, filename, ...)


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Network edges are clickable and open associated evidence links in a new browser tab with URL validation and error handling.
  * This behavior is active in both exported HTML files and in-browser previews.
  * Edges now include a statement identifier (statement hash) in their data for easier reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->