### PR TITLE
fix(curation): Use matches_hash for statement hash due to string issues

### DIFF
--- a/R/utils_getSubnetworkFromIndra.R
+++ b/R/utils_getSubnetworkFromIndra.R
@@ -125,7 +125,8 @@
     }
     if (filter_by_curation) {
         for (i in seq_along(res)) {
-            stmt_hash <- res[[i]]$data$stmt_hash
+            stmt_json <- fromJSON(res[[i]]$data$stmt_json)
+            stmt_hash <- stmt_json$matches_hash
             incorrect_count <- .get_incorrect_curation_count(stmt_hash, api_key)
             res[[i]]$data$evidence_count <- res[[i]]$data$evidence_count - incorrect_count
             # Todo: Also subtract source_counts accordingly if requested

--- a/R/utils_getSubnetworkFromIndra.R
+++ b/R/utils_getSubnetworkFromIndra.R
@@ -302,7 +302,8 @@
             query(res, x)$data$source_counts
         }, ""),
         stmt_hash = vapply(keys(res), function(x) {
-            as.character(query(res, x)$data$stmt_hash)
+            stmt_json <- fromJSON(query(res, x)$data$stmt_json)
+            stmt_json$matches_hash
         }, ""),
         stringsAsFactors = FALSE
     )


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified statement identifier extraction to derive values from JSON payloads instead of direct data fields, affecting curation filtering and edge construction processes in the data processing pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->