### PR TITLE
Filter by PTM site match

### DIFF
--- a/R/getSubnetworkFromIndra.R
+++ b/R/getSubnetworkFromIndra.R
@@ -69,7 +69,7 @@ getSubnetworkFromIndra <- function(input,
     edges <- .filterEdgesDataFrame(edges, paper_count_cutoff, correlation_cutoff)
     nodes <- .constructNodesDataFrame(input, edges)
     subnetwork = .filterByPtmSite(nodes, edges, filter_by_ptm_site)
-    subnetwork = .filterByCuration(subnetwork$nodes, subnetwork$edges, filter_by_curation)
+    subnetwork = .filterByCuration(subnetwork$nodes, subnetwork$edges, evidence_count_cutoff, filter_by_curation)
     warning(
         "NOTICE: This function includes third-party software components
         that are licensed under the BSD 2-Clause License. Please ensure to

--- a/R/getSubnetworkFromIndra.R
+++ b/R/getSubnetworkFromIndra.R
@@ -32,6 +32,9 @@
 #' as "namespace:identifier", e.g. "HGNC:1234" or "CHEBI:4911".
 #' @param filter_by_curation logical, whether to filter out statements that
 #' have been curated as incorrect in INDRA.  Default is FALSE.
+#' @param filter_by_ptm_site logical, whether to filter edges based on whether the 
+#' site information from INDRA matches with the PTM site in the input.  Default is FALSE.  
+#' Only applicable for differential PTM abundance results.
 #'
 #' @return list of 2 data.frames, nodes and edges
 #'
@@ -56,7 +59,8 @@ getSubnetworkFromIndra <- function(input,
                                    sources_filter = NULL,
                                    logfc_cutoff = NULL,
                                    force_include_other = NULL, 
-                                   filter_by_curation = FALSE) {
+                                   filter_by_curation = FALSE,
+                                   filter_by_ptm_site = FALSE) {
     input <- .filterGetSubnetworkFromIndraInput(input, pvalueCutoff, logfc_cutoff, force_include_other)
     .validateGetSubnetworkFromIndraInput(input, protein_level_data, sources_filter, force_include_other)
     res <- .callIndraCogexApi(input$HgncId, force_include_other)
@@ -64,13 +68,8 @@ getSubnetworkFromIndra <- function(input,
     edges <- .constructEdgesDataFrame(res, input, protein_level_data)
     edges <- .filterEdgesDataFrame(edges, paper_count_cutoff, correlation_cutoff)
     nodes <- .constructNodesDataFrame(input, edges)
-    if (nrow(nodes[!is.na(nodes$Site), ]) > 0) {
-        ptm_overlap <- calculatePTMOverlapAggregated(edges, nodes)
-        edges <- edges[ptm_overlap[paste(edges$source, edges$target, edges$interaction, sep = "-")] != "", ]
-        edges <- edges[!is.na(edges$site),]
-        nodes <- nodes[nodes$id %in% c(edges$source, edges$target), ]
-    }
-    subnetwork = .filterByCuration(nodes, edges, filter_by_curation)
+    subnetwork = .filterByPtmSite(nodes, edges, filter_by_ptm_site)
+    subnetwork = .filterByCuration(subnetwork$nodes, subnetwork$edges, filter_by_curation)
     warning(
         "NOTICE: This function includes third-party software components
         that are licensed under the BSD 2-Clause License. Please ensure to
@@ -78,5 +77,5 @@ getSubnetworkFromIndra <- function(input,
         package or utilizing the results based on this package.
         See the LICENSE file for more details."
     )
-    return(list(nodes = nodes, edges = edges))
+    return(subnetwork)
 }

--- a/R/getSubnetworkFromIndra.R
+++ b/R/getSubnetworkFromIndra.R
@@ -66,10 +66,12 @@ getSubnetworkFromIndra <- function(input,
     edges <- .constructEdgesDataFrame(res, input, protein_level_data)
     edges <- .filterEdgesDataFrame(edges, paper_count_cutoff, correlation_cutoff)
     nodes <- .constructNodesDataFrame(input, edges)
-    ptm_overlap <- calculatePTMOverlapAggregated(edges, nodes)
-    edges <- edges[ptm_overlap[paste(edges$source, edges$target, edges$interaction, sep = "-")] != "", ]
-    edges <- edges[!is.na(edges$site),]
-    nodes <- nodes[nodes$id %in% c(edges$source, edges$target), ]
+    if (nrow(edges[!is.na(edges$site), ]) > 0) {
+        ptm_overlap <- calculatePTMOverlapAggregated(edges, nodes)
+        edges <- edges[ptm_overlap[paste(edges$source, edges$target, edges$interaction, sep = "-")] != "", ]
+        edges <- edges[!is.na(edges$site),]
+        nodes <- nodes[nodes$id %in% c(edges$source, edges$target), ]
+    }
     if (filter_by_curation) {
         incorrect_counts <- numeric(nrow(edges))
         for (i in seq_len(nrow(edges))) {

--- a/R/getSubnetworkFromIndra.R
+++ b/R/getSubnetworkFromIndra.R
@@ -72,16 +72,7 @@ getSubnetworkFromIndra <- function(input,
         edges <- edges[!is.na(edges$site),]
         nodes <- nodes[nodes$id %in% c(edges$source, edges$target), ]
     }
-    if (filter_by_curation) {
-        incorrect_counts <- numeric(nrow(edges))
-        for (i in seq_len(nrow(edges))) {
-            incorrect_counts[i] <- .get_incorrect_curation_count(edges$stmt_hash[i], api_key)
-            Sys.sleep(0.1)
-        }
-        edges$evidenceCount <- edges$evidenceCount - incorrect_counts
-        edges <- edges[edges$evidenceCount >= evidence_count_cutoff, ]
-        nodes <- nodes[nodes$id %in% c(edges$source, edges$target), ]
-    }
+    subnetwork = .filterByCuration(nodes, edges, filter_by_curation)
     warning(
         "NOTICE: This function includes third-party software components
         that are licensed under the BSD 2-Clause License. Please ensure to

--- a/R/getSubnetworkFromIndra.R
+++ b/R/getSubnetworkFromIndra.R
@@ -70,12 +70,12 @@ getSubnetworkFromIndra <- function(input,
     edges <- edges[ptm_overlap[paste(edges$source, edges$target, edges$interaction, sep = "-")] != "", ]
     nodes <- nodes[nodes$id %in% c(edges$source, edges$target), ]
     if (filter_by_curation) {
-        for (i in seq(1, nrow(edges))) {
-            stmt_hash <- edges$stmt_hash[i]
-            incorrect_count <- .get_incorrect_curation_count(stmt_hash, api_key)
-            edges$evidence_count[i] <- edges$evidence_count[i] - incorrect_count
+        incorrect_counts <- numeric(nrow(edges))
+        for (i in seq_len(nrow(edges))) {
+            incorrect_counts[i] <- .get_incorrect_curation_count(edges$stmt_hash[i], api_key)
             Sys.sleep(0.1)
         }
+        edges$evidenceCount <- edges$evidenceCount - incorrect_counts
         edges <- edges[edges$evidenceCount >= evidence_count_cutoff, ]
         nodes <- nodes[nodes$id %in% c(edges$source, edges$target), ]
     }

--- a/R/getSubnetworkFromIndra.R
+++ b/R/getSubnetworkFromIndra.R
@@ -32,7 +32,6 @@
 #' as "namespace:identifier", e.g. "HGNC:1234" or "CHEBI:4911".
 #' @param filter_by_curation logical, whether to filter out statements that
 #' have been curated as incorrect in INDRA.  Default is FALSE.
-#' @param api_key string of INDRA API key for accessing curated statements.
 #'
 #' @return list of 2 data.frames, nodes and edges
 #'
@@ -57,8 +56,7 @@ getSubnetworkFromIndra <- function(input,
                                    sources_filter = NULL,
                                    logfc_cutoff = NULL,
                                    force_include_other = NULL, 
-                                   filter_by_curation = FALSE, 
-                                   api_key = "") {
+                                   filter_by_curation = FALSE) {
     input <- .filterGetSubnetworkFromIndraInput(input, pvalueCutoff, logfc_cutoff, force_include_other)
     .validateGetSubnetworkFromIndraInput(input, protein_level_data, sources_filter, force_include_other)
     res <- .callIndraCogexApi(input$HgncId, force_include_other)

--- a/R/getSubnetworkFromIndra.R
+++ b/R/getSubnetworkFromIndra.R
@@ -69,6 +69,16 @@ getSubnetworkFromIndra <- function(input,
     ptm_overlap <- calculatePTMOverlapAggregated(edges, nodes)
     edges <- edges[ptm_overlap[paste(edges$source, edges$target, edges$interaction, sep = "-")] != "", ]
     nodes <- nodes[nodes$id %in% c(edges$source, edges$target), ]
+    if (filter_by_curation) {
+        for (i in seq(1, nrow(edges))) {
+            stmt_hash <- edges$statement_hash[i]
+            incorrect_count <- .get_incorrect_curation_count(stmt_hash, api_key)
+            edges$evidence_count[i] <- edges$evidence_count[i] - incorrect_count
+            Sys.sleep(0.1)
+        }
+        edges <- edges[edges$evidence_count >= evidence_count_cutoff, ]
+        nodes <- nodes[nodes$id %in% c(edges$source, edges$target), ]
+    }
     warning(
         "NOTICE: This function includes third-party software components
         that are licensed under the BSD 2-Clause License. Please ensure to

--- a/R/getSubnetworkFromIndra.R
+++ b/R/getSubnetworkFromIndra.R
@@ -64,7 +64,7 @@ getSubnetworkFromIndra <- function(input,
     input <- .filterGetSubnetworkFromIndraInput(input, pvalueCutoff, logfc_cutoff, force_include_other)
     .validateGetSubnetworkFromIndraInput(input, protein_level_data, sources_filter, force_include_other)
     res <- .callIndraCogexApi(input$HgncId, force_include_other)
-    res <- .filterIndraResponse(res, statement_types, evidence_count_cutoff, sources_filter, filter_by_curation, api_key)
+    res <- .filterIndraResponse(res, statement_types, evidence_count_cutoff, sources_filter)
     edges <- .constructEdgesDataFrame(res, input, protein_level_data)
     edges <- .filterEdgesDataFrame(edges, paper_count_cutoff, correlation_cutoff)
     nodes <- .constructNodesDataFrame(input, edges)

--- a/R/getSubnetworkFromIndra.R
+++ b/R/getSubnetworkFromIndra.R
@@ -66,6 +66,9 @@ getSubnetworkFromIndra <- function(input,
     edges <- .constructEdgesDataFrame(res, input, protein_level_data)
     edges <- .filterEdgesDataFrame(edges, paper_count_cutoff, correlation_cutoff)
     nodes <- .constructNodesDataFrame(input, edges)
+    ptm_overlap <- calculatePTMOverlapAggregated(edges, nodes)
+    edges <- edges[ptm_overlap[paste(edges$source, edges$target, edges$interaction, sep = "-")] != "", ]
+    nodes <- nodes[nodes$id %in% c(edges$source, edges$target), ]
     warning(
         "NOTICE: This function includes third-party software components
         that are licensed under the BSD 2-Clause License. Please ensure to

--- a/R/getSubnetworkFromIndra.R
+++ b/R/getSubnetworkFromIndra.R
@@ -68,6 +68,7 @@ getSubnetworkFromIndra <- function(input,
     nodes <- .constructNodesDataFrame(input, edges)
     ptm_overlap <- calculatePTMOverlapAggregated(edges, nodes)
     edges <- edges[ptm_overlap[paste(edges$source, edges$target, edges$interaction, sep = "-")] != "", ]
+    edges <- edges[!is.na(edges$site),]
     nodes <- nodes[nodes$id %in% c(edges$source, edges$target), ]
     if (filter_by_curation) {
         incorrect_counts <- numeric(nrow(edges))

--- a/R/getSubnetworkFromIndra.R
+++ b/R/getSubnetworkFromIndra.R
@@ -76,7 +76,7 @@ getSubnetworkFromIndra <- function(input,
             edges$evidence_count[i] <- edges$evidence_count[i] - incorrect_count
             Sys.sleep(0.1)
         }
-        edges <- edges[edges$evidence_count >= evidence_count_cutoff, ]
+        edges <- edges[edges$evidenceCount >= evidence_count_cutoff, ]
         nodes <- nodes[nodes$id %in% c(edges$source, edges$target), ]
     }
     warning(

--- a/R/getSubnetworkFromIndra.R
+++ b/R/getSubnetworkFromIndra.R
@@ -71,7 +71,7 @@ getSubnetworkFromIndra <- function(input,
     nodes <- nodes[nodes$id %in% c(edges$source, edges$target), ]
     if (filter_by_curation) {
         for (i in seq(1, nrow(edges))) {
-            stmt_hash <- edges$statement_hash[i]
+            stmt_hash <- edges$stmt_hash[i]
             incorrect_count <- .get_incorrect_curation_count(stmt_hash, api_key)
             edges$evidence_count[i] <- edges$evidence_count[i] - incorrect_count
             Sys.sleep(0.1)

--- a/R/getSubnetworkFromIndra.R
+++ b/R/getSubnetworkFromIndra.R
@@ -66,7 +66,7 @@ getSubnetworkFromIndra <- function(input,
     edges <- .constructEdgesDataFrame(res, input, protein_level_data)
     edges <- .filterEdgesDataFrame(edges, paper_count_cutoff, correlation_cutoff)
     nodes <- .constructNodesDataFrame(input, edges)
-    if (nrow(edges[!is.na(edges$site), ]) > 0) {
+    if (nrow(nodes[!is.na(nodes$Site), ]) > 0) {
         ptm_overlap <- calculatePTMOverlapAggregated(edges, nodes)
         edges <- edges[ptm_overlap[paste(edges$source, edges$target, edges$interaction, sep = "-")] != "", ]
         edges <- edges[!is.na(edges$site),]

--- a/R/utils_getSubnetworkFromIndra.R
+++ b/R/utils_getSubnetworkFromIndra.R
@@ -96,18 +96,18 @@
 
 #' Call INDRA Cogex API and return response
 #' @param res response from INDRA
-#' @param interaction_types interaction types to filter by
+#' @param statement_types interaction types to filter by
 #' @param evidence_count_cutoff number of evidence to filter on for each paper
 #' @param sources_filter list of sources to filter by. Default is NULL, i.e. no filter
 #' @return filtered list of INDRA statements
 #' @importFrom jsonlite fromJSON
 #' @keywords internal
 #' @noRd
-.filterIndraResponse <- function(res, interaction_types, evidence_count_cutoff, 
+.filterIndraResponse <- function(res, statement_types, evidence_count_cutoff, 
                                  sources_filter = NULL) {
-    if (!is.null(interaction_types)) {
+    if (!is.null(statement_types)) {
         res = Filter(
-            function(statement) statement$data$stmt_type %in% interaction_types, 
+            function(statement) statement$data$stmt_type %in% statement_types, 
             res)
     }
     if (!is.null(sources_filter)) {

--- a/R/utils_getSubnetworkFromIndra.R
+++ b/R/utils_getSubnetworkFromIndra.R
@@ -374,6 +374,16 @@
     return(list(nodes = nodes, edges = edges))
 }
 
+.filterByPtmSite = function(nodes, edges, filter_by_ptm_site) {
+    if (filter_by_ptm_site && nrow(nodes[!is.na(nodes$Site), ]) > 0) {
+        ptm_overlap <- calculatePTMOverlapAggregated(edges, nodes)
+        edges <- edges[ptm_overlap[paste(edges$source, edges$target, edges$interaction, sep = "-")] != "", ]
+        edges <- edges[!is.na(edges$site),]
+        nodes <- nodes[nodes$id %in% c(edges$source, edges$target), ]
+    }
+    return(list(nodes = nodes, edges = edges))
+}
+
 #' Construct correlation matrix from MSstats
 #' @param protein_level_data output of dataProcess
 #' @importFrom tidyr pivot_wider

--- a/R/utils_getSubnetworkFromIndra.R
+++ b/R/utils_getSubnetworkFromIndra.R
@@ -123,16 +123,16 @@
             res
         )
     }
-    if (filter_by_curation) {
-        for (i in seq_along(res)) {
-            stmt_json <- fromJSON(res[[i]]$data$stmt_json)
-            stmt_hash <- stmt_json$matches_hash
-            incorrect_count <- .get_incorrect_curation_count(stmt_hash, api_key)
-            res[[i]]$data$evidence_count <- res[[i]]$data$evidence_count - incorrect_count
-            # Todo: Also subtract source_counts accordingly if requested
-            Sys.sleep(0.1)
-        }
-    }
+    # if (filter_by_curation) {
+    #     for (i in seq_along(res)) {
+    #         stmt_json <- fromJSON(res[[i]]$data$stmt_json)
+    #         stmt_hash <- stmt_json$matches_hash
+    #         incorrect_count <- .get_incorrect_curation_count(stmt_hash, api_key)
+    #         res[[i]]$data$evidence_count <- res[[i]]$data$evidence_count - incorrect_count
+    #         # Todo: Also subtract source_counts accordingly if requested
+    #         Sys.sleep(0.1)
+    #     }
+    # }
     res = Filter(
         function(statement) statement$data$evidence_count >= evidence_count_cutoff, 
         res

--- a/R/utils_getSubnetworkFromIndra.R
+++ b/R/utils_getSubnetworkFromIndra.R
@@ -376,7 +376,7 @@
 
 .filterByPtmSite = function(nodes, edges, filter_by_ptm_site) {
     if (filter_by_ptm_site && nrow(nodes[!is.na(nodes$Site), ]) > 0) {
-        ptm_overlap <- calculatePTMOverlapAggregated(edges, nodes)
+        ptm_overlap <- .calculatePTMOverlapAggregated(edges, nodes)
         keep <- ptm_overlap[paste(edges$source, edges$target, edges$interaction, sep = "-")]
         edges <- edges[!is.na(keep) & keep != "", ]
         edges <- edges[!is.na(edges$site),]

--- a/R/utils_getSubnetworkFromIndra.R
+++ b/R/utils_getSubnetworkFromIndra.R
@@ -99,15 +99,12 @@
 #' @param interaction_types interaction types to filter by
 #' @param evidence_count_cutoff number of evidence to filter on for each paper
 #' @param sources_filter list of sources to filter by. Default is NULL, i.e. no filter
-#' @param filter_by_curation logical, whether to filter out statements that
-#' have been curated as incorrect in INDRA.  Default is FALSE.
-#' @param api_key string of INDRA API key for accessing curated statements.
 #' @return filtered list of INDRA statements
 #' @importFrom jsonlite fromJSON
 #' @keywords internal
 #' @noRd
 .filterIndraResponse <- function(res, interaction_types, evidence_count_cutoff, 
-                                 sources_filter = NULL, filter_by_curation = FALSE, api_key = "") {
+                                 sources_filter = NULL) {
     if (!is.null(interaction_types)) {
         res = Filter(
             function(statement) statement$data$stmt_type %in% interaction_types, 
@@ -123,16 +120,6 @@
             res
         )
     }
-    # if (filter_by_curation) {
-    #     for (i in seq_along(res)) {
-    #         stmt_json <- fromJSON(res[[i]]$data$stmt_json)
-    #         stmt_hash <- stmt_json$matches_hash
-    #         incorrect_count <- .get_incorrect_curation_count(stmt_hash, api_key)
-    #         res[[i]]$data$evidence_count <- res[[i]]$data$evidence_count - incorrect_count
-    #         # Todo: Also subtract source_counts accordingly if requested
-    #         Sys.sleep(0.1)
-    #     }
-    # }
     res = Filter(
         function(statement) statement$data$evidence_count >= evidence_count_cutoff, 
         res
@@ -371,6 +358,20 @@
         stop("No edges remain after applying filters. Consider relaxing filters")
     }
     return(edges)
+}
+
+.filterByCuration = function(nodes, edges, filter_by_curation) {
+    if (filter_by_curation) {
+        incorrect_counts <- numeric(nrow(edges))
+        for (i in seq_len(nrow(edges))) {
+            incorrect_counts[i] <- .get_incorrect_curation_count(edges$stmt_hash[i], api_key)
+            Sys.sleep(0.1)
+        }
+        edges$evidenceCount <- edges$evidenceCount - incorrect_counts
+        edges <- edges[edges$evidenceCount >= evidence_count_cutoff, ]
+        nodes <- nodes[nodes$id %in% c(edges$source, edges$target), ]
+    }
+    return(list(nodes = nodes, edges = edges))
 }
 
 #' Construct correlation matrix from MSstats

--- a/R/utils_getSubnetworkFromIndra.R
+++ b/R/utils_getSubnetworkFromIndra.R
@@ -68,9 +68,9 @@
 
 #' @importFrom httr GET status_code content
 #' @importFrom jsonlite fromJSON
-.get_incorrect_curation_count <- function(stmt_hash, api_key) {
+.get_incorrect_curation_count <- function(stmt_hash) {
     stmt_hash_char <- as.character(stmt_hash)
-    url <- paste0("https://db.indra.bio/curation/list/", stmt_hash_char, "?api_key=", api_key)
+    url <- paste0("https://db.indra.bio/curation/list/", stmt_hash_char)
 
     tryCatch({
         response <- GET(url)
@@ -364,7 +364,7 @@
     if (filter_by_curation) {
         incorrect_counts <- numeric(nrow(edges))
         for (i in seq_len(nrow(edges))) {
-            incorrect_counts[i] <- .get_incorrect_curation_count(edges$stmt_hash[i], api_key)
+            incorrect_counts[i] <- .get_incorrect_curation_count(edges$stmt_hash[i])
             Sys.sleep(0.1)
         }
         edges$evidenceCount <- edges$evidenceCount - incorrect_counts

--- a/R/utils_getSubnetworkFromIndra.R
+++ b/R/utils_getSubnetworkFromIndra.R
@@ -360,7 +360,7 @@
     return(edges)
 }
 
-.filterByCuration = function(nodes, edges, filter_by_curation) {
+.filterByCuration = function(nodes, edges, evidence_count_cutoff, filter_by_curation) {
     if (filter_by_curation) {
         incorrect_counts <- numeric(nrow(edges))
         for (i in seq_len(nrow(edges))) {
@@ -377,7 +377,8 @@
 .filterByPtmSite = function(nodes, edges, filter_by_ptm_site) {
     if (filter_by_ptm_site && nrow(nodes[!is.na(nodes$Site), ]) > 0) {
         ptm_overlap <- calculatePTMOverlapAggregated(edges, nodes)
-        edges <- edges[ptm_overlap[paste(edges$source, edges$target, edges$interaction, sep = "-")] != "", ]
+        keep <- ptm_overlap[paste(edges$source, edges$target, edges$interaction, sep = "-")]
+        edges <- edges[!is.na(keep) & keep != "", ]
         edges <- edges[!is.na(edges$site),]
         nodes <- nodes[nodes$id %in% c(edges$source, edges$target), ]
     }

--- a/R/visualizeNetworksWithHTML.R
+++ b/R/visualizeNetworksWithHTML.R
@@ -78,6 +78,7 @@ getRelationshipProperties <- function() {
 #' @param edges Data frame with edge information including 'target' and 'site' columns
 #' @param nodes Data frame with node information including 'id' and 'Site' columns
 #' @return Vector of overlap descriptions for each unique edge (after consolidation)
+#' @keywords internal
 #' @noRd
 calculatePTMOverlapAggregated <- function(edges, nodes) {
     if (nrow(edges) == 0) return(character(0))
@@ -1141,6 +1142,7 @@ createEdgeClickHandler <- function() {
 #' @param edges Data frame with edge information  
 #' @param filename Output HTML filename
 #' @param displayLabelType Type of label to display ("id" or "hgncName")
+#' @param nodeFontSize Font size for node labels (default: 12)
 #' @param ... Additional arguments passed to exportCytoscapeToHTML()
 #' @export
 #' @return Invisibly returns the file path of the created HTML file

--- a/R/visualizeNetworksWithHTML.R
+++ b/R/visualizeNetworksWithHTML.R
@@ -80,7 +80,7 @@ getRelationshipProperties <- function() {
 #' @return Vector of overlap descriptions for each unique edge (after consolidation)
 #' @keywords internal
 #' @noRd
-calculatePTMOverlapAggregated <- function(edges, nodes) {
+.calculatePTMOverlapAggregated <- function(edges, nodes) {
     if (nrow(edges) == 0) return(character(0))
     
     # Group edges by source-target-interaction to match consolidation logic
@@ -154,7 +154,7 @@ consolidateEdges <- function(edges, nodes = NULL) {
     
     # Calculate aggregated PTM overlap information if nodes are provided
     ptm_overlap_map <- if (!is.null(nodes)) {
-        calculatePTMOverlapAggregated(edges, nodes)
+        .calculatePTMOverlapAggregated(edges, nodes)
     } else {
         NULL
     }

--- a/man/exportNetworkToHTML.Rd
+++ b/man/exportNetworkToHTML.Rd
@@ -9,6 +9,7 @@ exportNetworkToHTML(
   edges,
   filename = "network_visualization.html",
   displayLabelType = "id",
+  nodeFontSize = 12,
   ...
 )
 }

--- a/man/exportNetworkToHTML.Rd
+++ b/man/exportNetworkToHTML.Rd
@@ -22,6 +22,8 @@ exportNetworkToHTML(
 
 \item{displayLabelType}{Type of label to display ("id" or "hgncName")}
 
+\item{nodeFontSize}{Font size for node labels (default: 12)}
+
 \item{...}{Additional arguments passed to exportCytoscapeToHTML()}
 }
 \value{

--- a/man/generateCytoscapeConfig.Rd
+++ b/man/generateCytoscapeConfig.Rd
@@ -10,7 +10,8 @@ generateCytoscapeConfig(
   display_label_type = "id",
   container_id = "network-cy",
   event_handlers = NULL,
-  layout_options = NULL
+  layout_options = NULL,
+  node_font_size = 12
 )
 }
 \arguments{

--- a/man/getSubnetworkFromIndra.Rd
+++ b/man/getSubnetworkFromIndra.Rd
@@ -15,7 +15,8 @@ getSubnetworkFromIndra(
   sources_filter = NULL,
   logfc_cutoff = NULL,
   force_include_other = NULL,
-  filter_by_curation = FALSE
+  filter_by_curation = FALSE,
+  filter_by_ptm_site = FALSE
 )
 }
 \arguments{
@@ -58,6 +59,10 @@ as "namespace:identifier", e.g. "HGNC:1234" or "CHEBI:4911".}
 
 \item{filter_by_curation}{logical, whether to filter out statements that
 have been curated as incorrect in INDRA.  Default is FALSE.}
+
+\item{filter_by_ptm_site}{logical, whether to filter edges based on whether the 
+site information from INDRA matches with the PTM site in the input.  Default is FALSE.  
+Only applicable for differential PTM abundance results.}
 }
 \value{
 list of 2 data.frames, nodes and edges

--- a/man/getSubnetworkFromIndra.Rd
+++ b/man/getSubnetworkFromIndra.Rd
@@ -15,8 +15,7 @@ getSubnetworkFromIndra(
   sources_filter = NULL,
   logfc_cutoff = NULL,
   force_include_other = NULL,
-  filter_by_curation = FALSE,
-  api_key = ""
+  filter_by_curation = FALSE
 )
 }
 \arguments{
@@ -59,8 +58,6 @@ as "namespace:identifier", e.g. "HGNC:1234" or "CHEBI:4911".}
 
 \item{filter_by_curation}{logical, whether to filter out statements that
 have been curated as incorrect in INDRA.  Default is FALSE.}
-
-\item{api_key}{string of INDRA API key for accessing curated statements.}
 }
 \value{
 list of 2 data.frames, nodes and edges

--- a/man/previewNetworkInBrowser.Rd
+++ b/man/previewNetworkInBrowser.Rd
@@ -4,7 +4,13 @@
 \alias{previewNetworkInBrowser}
 \title{Preview network in browser}
 \usage{
-previewNetworkInBrowser(nodes, edges, displayLabelType = "id", ...)
+previewNetworkInBrowser(
+  nodes,
+  edges,
+  displayLabelType = "id",
+  nodeFontSize = 12,
+  ...
+)
 }
 \arguments{
 \item{nodes}{Data frame with node information}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation and Context

This PR adds PTM-site-based filtering to INDRA-derived subnetworks to make extracted interactions more relevant for phospho/PTM-centric proteomics analyses. It refactors the INDRA filtering pipeline into discrete helper steps (PTM-site filtering then curation filtering) and exposes new visualization font-size parameters for HTML/Cytoscape outputs. The aim is to (1) allow optional removal of INDRA edges that do not match input PTM-site information and (2) separate curation adjustments into a dedicated helper.

## Solution summary

- Introduced an optional parameter to filter INDRA edges by matching PTM site information from input PTM results prior to curation filtering.
- Refactored the INDRA filtering pipeline into .filterByPtmSite() and .filterByCuration() helpers and updated getSubnetworkFromIndra to run PTM-site filtering then curation filtering, returning the chained subnetwork result.
- Removed api_key usage from several INDRA-related helpers and from the main call site.
- Added node font-size parameters to the HTML/Cytoscape visualization API and propagated the value through the config generation pipeline.

## Detailed changes

- R/getSubnetworkFromIndra.R
  - Replaced api_key parameter with filter_by_ptm_site = FALSE in the public signature.
  - Added call to .filterByPtmSite(nodes, edges, filter_by_ptm_site) and then .filterByCuration(...) — now returns the filtered subnetwork.
  - Removed passing api_key into .filterIndraResponse; .filterIndraResponse is now called without api_key.

- R/utils_getSubnetworkFromIndra.R
  - Removed api_key from .get_incorrect_curation_count() and adjusted its request logic to query INDRA curation list without requiring an API key.
  - Simplified .filterIndraResponse() signature by removing api_key and filter_by_curation; inlined curation-adjusting logic was removed.
  - Added .filterByPtmSite(nodes, edges, filter_by_ptm_site): filters edges lacking INDRA site matches to input PTM sites using calculatePTMOverlapAggregated().
  - Added .filterByCuration(nodes, edges, evidence_count_cutoff, filter_by_curation): queries incorrect curation counts and adjusts/evaluates evidence counts before filtering edges.
  - Reworked code comments and roxygen docs to reflect new helper functions and parameter changes.

- R/visualizeNetworksWithHTML.R, man/exportNetworkToHTML.Rd, man/generateCytoscapeConfig.Rd, man/previewNetworkInBrowser.Rd
  - Added nodeFontSize (public) / node_font_size (internal) parameter with default 12 to control node label font size in HTML/Cytoscape visualizations.
  - Propagated the font-size parameter through exportNetworkToHTML -> generateCytoscapeConfig -> createNodeElements.

- Documentation
  - Updated roxygen/Rd docs for getSubnetworkFromIndra to replace api_key with filter_by_ptm_site and document applicability (differential PTM abundance use case).
  - Updated man pages for visualization functions to document new font-size parameters.

- Public API changes
  - getSubnetworkFromIndra signature changed; default behavior preserved but parameter list altered (breaking change).
  - Return value now the filtered subnetwork (output of new helper chain) rather than previously assembled nodes/edges list.

## Unit tests added or modified

- No new unit tests were added for:
  - filter_by_ptm_site behavior (.filterByPtmSite)
  - .filterByCuration behavior and interaction with INDRA curation counts
  - The path combinations (filter_by_ptm_site TRUE/FALSE + filter_by_curation TRUE/FALSE)
  - Visualization parameter propagation (nodeFontSize/node_font_size)
- Existing tests for getSubnetworkFromIndra remain limited to basic structure and input validation and do not exercise the new filtering logic. The PR’s description/checklist shows testing steps left empty.

## Coding guidelines and potential issues

- Breaking API change: Removing api_key from public getSubnetworkFromIndra is a breaking change with no deprecation/migration guidance in docs or the PR description.
- Missing tests: New functionality and refactored paths lack unit tests and mocks to validate behavior and edge cases.
- Potential runtime/scoping bug: .filterByCuration() adjusts and filters edges by evidence_count_cutoff; verify that evidence_count_cutoff is passed into or available to that function (the diff summary suggests the helper receives evidence_count_cutoff but reviewers should confirm the implementation does not rely on an unbound variable).
- Behavior change risk: .filterIndraResponse() no longer adjusts evidence counts via api-key-based curation lookup; ensure the new .filterByCuration() correctly reimplements prior behavior and that removing api_key does not break authenticated endpoints or rate-limited access in deployment contexts.
- Documentation vs. implementation: The PR updates Rd/roxygen docs but checklist items for contributing guidelines, change warnings, dependent changes, code styling, and documentation generation are unchecked — ensure CI/doc build and contribution-policy compliance before merge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->