### PR TITLE
feat(getSubnetworkFromIndra): Add filter for including infinity fold change

### DIFF
--- a/R/getSubnetworkFromIndra.R
+++ b/R/getSubnetworkFromIndra.R
@@ -38,6 +38,9 @@
 #' @param include_infinite_fc logical, whether to include proteins with 
 #' infinite log fold change (i.e. proteins that are only detected in one condition).  
 #' Default is FALSE.
+#' @param direction Character string specifying the direction of regulation to
+#' include. One of \code{"both"} (default), \code{"up"} (upregulated only),
+#' or \code{"down"} (downregulated only).
 #'
 #' @return list of 2 data.frames, nodes and edges
 #'
@@ -64,8 +67,10 @@ getSubnetworkFromIndra <- function(input,
                                    force_include_other = NULL, 
                                    filter_by_curation = FALSE,
                                    filter_by_ptm_site = FALSE,
-                                   include_infinite_fc = FALSE) {
-    input <- .filterGetSubnetworkFromIndraInput(input, pvalueCutoff, logfc_cutoff, force_include_other, include_infinite_fc)
+                                   include_infinite_fc = FALSE,
+                                   direction = c("both", "up", "down")) {
+    direction = match.arg(direction)
+    input <- .filterGetSubnetworkFromIndraInput(input, pvalueCutoff, logfc_cutoff, force_include_other, include_infinite_fc, direction)
     .validateGetSubnetworkFromIndraInput(input, protein_level_data, sources_filter, force_include_other)
     res <- .callIndraCogexApi(input$HgncId, force_include_other)
     res <- .filterIndraResponse(res, statement_types, evidence_count_cutoff, sources_filter)

--- a/R/getSubnetworkFromIndra.R
+++ b/R/getSubnetworkFromIndra.R
@@ -35,6 +35,9 @@
 #' @param filter_by_ptm_site logical, whether to filter edges based on whether the 
 #' site information from INDRA matches with the PTM site in the input.  Default is FALSE.  
 #' Only applicable for differential PTM abundance results.
+#' @param include_infinite_fc logical, whether to include proteins with 
+#' infinite log fold change (i.e. proteins that are only detected in one condition).  
+#' Default is FALSE.
 #'
 #' @return list of 2 data.frames, nodes and edges
 #'
@@ -60,8 +63,9 @@ getSubnetworkFromIndra <- function(input,
                                    logfc_cutoff = NULL,
                                    force_include_other = NULL, 
                                    filter_by_curation = FALSE,
-                                   filter_by_ptm_site = FALSE) {
-    input <- .filterGetSubnetworkFromIndraInput(input, pvalueCutoff, logfc_cutoff, force_include_other)
+                                   filter_by_ptm_site = FALSE,
+                                   include_infinite_fc = FALSE) {
+    input <- .filterGetSubnetworkFromIndraInput(input, pvalueCutoff, logfc_cutoff, force_include_other, include_infinite_fc)
     .validateGetSubnetworkFromIndraInput(input, protein_level_data, sources_filter, force_include_other)
     res <- .callIndraCogexApi(input$HgncId, force_include_other)
     res <- .filterIndraResponse(res, statement_types, evidence_count_cutoff, sources_filter)

--- a/R/utils_cytoscapeNetwork.R
+++ b/R/utils_cytoscapeNetwork.R
@@ -10,9 +10,17 @@
         return(rep("#D3D3D3", length(logFC_values)))
     }
     
+    is_pos_inf <- is.infinite(logFC_values) & logFC_values > 0
+    is_neg_inf <- is.infinite(logFC_values) & logFC_values < 0
+    
+    finite_values   <- logFC_values[is.finite(logFC_values)]
     default_max     <- 2
-    max_logFC       <- max(c(abs(logFC_values), default_max), na.rm = TRUE)
+    max_logFC       <- max(c(abs(finite_values), default_max), na.rm = TRUE)
     min_logFC       <- -max_logFC
+    
+    logFC_values[is_pos_inf] <-  max_logFC
+    logFC_values[is_neg_inf] <-  min_logFC
+    
     color_map       <- grDevices::colorRamp(colors)
     normalized      <- (logFC_values - min_logFC) / (max_logFC - min_logFC)
     normalized[is.na(normalized)] <- 0.5

--- a/R/utils_getSubnetworkFromIndra.R
+++ b/R/utils_getSubnetworkFromIndra.R
@@ -135,10 +135,18 @@
 #' @param include_infinite_fc logical, whether to include proteins with 
 #' infinite log fold change (i.e. proteins that are only detected in one condition).  
 #' Default is FALSE. 
+#' @param direction Character string specifying the direction of regulation to
+#' include. One of \code{"both"} (default), \code{"up"} (upregulated only),
+#' or \code{"down"} (downregulated only).
 #' @return filtered groupComparison result
 #' @keywords internal
 #' @noRd
-.filterGetSubnetworkFromIndraInput <- function(input, pvalueCutoff, logfc_cutoff, force_include_other, include_infinite_fc) {
+.filterGetSubnetworkFromIndraInput <- function(input, 
+                                               pvalueCutoff, 
+                                               logfc_cutoff, 
+                                               force_include_other, 
+                                               include_infinite_fc, 
+                                               direction) {
     input$Protein <- as.character(input$Protein)
     
     # Extract exempt proteins before any filtering
@@ -171,15 +179,21 @@
         input <- input[!is.na(input$log2FC) & abs(input$log2FC) > logfc_cutoff, ]
     }
     
+    if (!is.null(infinite_fc_proteins) && nrow(infinite_fc_proteins) > 0) {
+        combined_input <- rbind(infinite_fc_proteins, input)
+        input <- combined_input[!duplicated(combined_input$Protein), ]
+    }
+    
+    if (direction == "up") {
+        input <- input[!is.na(input$log2FC) & input$log2FC > 0, ]
+    } else if (direction == "down") {
+        input <- input[!is.na(input$log2FC) & input$log2FC < 0, ]
+    }
+    
     # Combine filtered data with exempt proteins and remove duplicates
     if (!is.null(exempt_proteins) && nrow(exempt_proteins) > 0) {
         combined_input <- rbind(exempt_proteins, input)
         # Remove duplicates based on Protein column, keeping first occurrence
-        input <- combined_input[!duplicated(combined_input$Protein), ]
-    }
-    
-    if (!is.null(infinite_fc_proteins) && nrow(infinite_fc_proteins) > 0) {
-        combined_input <- rbind(infinite_fc_proteins, input)
         input <- combined_input[!duplicated(combined_input$Protein), ]
     }
     

--- a/R/utils_getSubnetworkFromIndra.R
+++ b/R/utils_getSubnetworkFromIndra.R
@@ -132,10 +132,13 @@
 #' @param pvalueCutoff p-value cutoff
 #' @param logfc_cutoff logFC cutoff
 #' @param force_include_other list of identifiers to exempt from filtering
+#' @param include_infinite_fc logical, whether to include proteins with 
+#' infinite log fold change (i.e. proteins that are only detected in one condition).  
+#' Default is FALSE. 
 #' @return filtered groupComparison result
 #' @keywords internal
 #' @noRd
-.filterGetSubnetworkFromIndraInput <- function(input, pvalueCutoff, logfc_cutoff, force_include_other) {
+.filterGetSubnetworkFromIndraInput <- function(input, pvalueCutoff, logfc_cutoff, force_include_other, include_infinite_fc) {
     input$Protein <- as.character(input$Protein)
     
     # Extract exempt proteins before any filtering
@@ -152,7 +155,11 @@
         }
     }
     
-    # Apply standard filtering
+    infinite_fc_proteins <- NULL
+    if (include_infinite_fc) {
+        infinite_fc_proteins <- input[is.infinite(input$log2FC), ]
+    }
+
     input <- input[!is.na(input$adj.pvalue),]
     if (!is.null(pvalueCutoff)) {
         input <- input[input$adj.pvalue < pvalueCutoff, ]
@@ -163,14 +170,16 @@
         }
         input <- input[!is.na(input$log2FC) & abs(input$log2FC) > logfc_cutoff, ]
     }
-    if ("issue" %in% colnames(input)) {
-        input <- input[is.na(input$issue), ]
-    }
     
     # Combine filtered data with exempt proteins and remove duplicates
     if (!is.null(exempt_proteins) && nrow(exempt_proteins) > 0) {
         combined_input <- rbind(exempt_proteins, input)
         # Remove duplicates based on Protein column, keeping first occurrence
+        input <- combined_input[!duplicated(combined_input$Protein), ]
+    }
+    
+    if (!is.null(infinite_fc_proteins) && nrow(infinite_fc_proteins) > 0) {
+        combined_input <- rbind(infinite_fc_proteins, input)
         input <- combined_input[!duplicated(combined_input$Protein), ]
     }
     
@@ -186,6 +195,7 @@
     }
     return(input)
 }
+
 #' Add additional metadata to an edge
 #' @param edge object representation of an INDRA statement
 #' @param input filtered groupComparison result

--- a/man/getSubnetworkFromIndra.Rd
+++ b/man/getSubnetworkFromIndra.Rd
@@ -16,7 +16,8 @@ getSubnetworkFromIndra(
   logfc_cutoff = NULL,
   force_include_other = NULL,
   filter_by_curation = FALSE,
-  filter_by_ptm_site = FALSE
+  filter_by_ptm_site = FALSE,
+  include_infinite_fc = FALSE
 )
 }
 \arguments{
@@ -63,6 +64,10 @@ have been curated as incorrect in INDRA.  Default is FALSE.}
 \item{filter_by_ptm_site}{logical, whether to filter edges based on whether the 
 site information from INDRA matches with the PTM site in the input.  Default is FALSE.  
 Only applicable for differential PTM abundance results.}
+
+\item{include_infinite_fc}{logical, whether to include proteins with 
+infinite log fold change (i.e. proteins that are only detected in one condition).  
+Default is FALSE.}
 }
 \value{
 list of 2 data.frames, nodes and edges

--- a/man/getSubnetworkFromIndra.Rd
+++ b/man/getSubnetworkFromIndra.Rd
@@ -17,7 +17,8 @@ getSubnetworkFromIndra(
   force_include_other = NULL,
   filter_by_curation = FALSE,
   filter_by_ptm_site = FALSE,
-  include_infinite_fc = FALSE
+  include_infinite_fc = FALSE,
+  direction = c("both", "up", "down")
 )
 }
 \arguments{
@@ -68,6 +69,10 @@ Only applicable for differential PTM abundance results.}
 \item{include_infinite_fc}{logical, whether to include proteins with 
 infinite log fold change (i.e. proteins that are only detected in one condition).  
 Default is FALSE.}
+
+\item{direction}{Character string specifying the direction of regulation to
+include. One of \code{"both"} (default), \code{"up"} (upregulated only),
+or \code{"down"} (downregulated only).}
 }
 \value{
 list of 2 data.frames, nodes and edges

--- a/tests/testthat/test-utils_cytoscapeNetwork.R
+++ b/tests/testthat/test-utils_cytoscapeNetwork.R
@@ -69,6 +69,12 @@ test_that(".mapLogFCToColor handles empty input", {
     expect_length(colors, 0)
 })
 
+test_that(".mapLogFCToColor handles Inf and -Inf values", {
+    colors <- MSstatsBioNet:::.mapLogFCToColor(c(-Inf, 0, Inf))
+    expect_length(colors, 3)
+    expect_true(all(grepl("^#[0-9A-Fa-f]{6}$", colors)))
+})
+
 # =============================================================================
 # .relProps
 # =============================================================================

--- a/tests/testthat/test-utils_getSubnetworkFromIndra.R
+++ b/tests/testthat/test-utils_getSubnetworkFromIndra.R
@@ -1,153 +1,215 @@
-make_nodes <- function() {
-    data.frame(
-        id       = c("P53_HUMAN", "MDM2_HUMAN", "ATM_HUMAN"),
-        logFC    = c(1.5, -1.0, 0.5),
-        Site     = c("S15_S20", "T68",  NA),
-        stringsAsFactors = FALSE
-    )
-}
-
-make_edges <- function() {
-    data.frame(
-        source      = c("ATM_HUMAN",  "ATM_HUMAN",  "P53_HUMAN",  "P53_HUMAN"),
-        target      = c("P53_HUMAN",  "MDM2_HUMAN", "MDM2_HUMAN", "ATM_HUMAN"),
-        interaction = c("Phosphorylation", "Phosphorylation", "Activation", "Activation"),
-        site        = c("S15",         "T999",        NA,            "S15"),
-        stringsAsFactors = FALSE
-    )
-}
-
-test_that(".filterByPtmSite returns input unchanged when filter_by_ptm_site = FALSE", {
-    nodes  <- make_nodes()
-    edges  <- make_edges()
-    result <- MSstatsBioNet:::.filterByPtmSite(nodes, edges, filter_by_ptm_site = FALSE)
+describe(".filterByPtmSite", { 
+    make_nodes <- function() {
+        data.frame(
+            id       = c("P53_HUMAN", "MDM2_HUMAN", "ATM_HUMAN"),
+            logFC    = c(1.5, -1.0, 0.5),
+            Site     = c("S15_S20", "T68",  NA),
+            stringsAsFactors = FALSE
+        )
+    }
     
-    expect_equal(nrow(result$nodes), nrow(nodes))
-    expect_equal(nrow(result$edges), nrow(edges))
-    expect_equal(result$nodes, nodes)
-    expect_equal(result$edges, edges)
-})
-
-test_that(".filterByPtmSite returns input unchanged when no nodes have Site data", {
-    nodes       <- make_nodes()
-    nodes$Site  <- NA   # wipe all sites
-    edges       <- make_edges()
+    make_edges <- function() {
+        data.frame(
+            source      = c("ATM_HUMAN",  "ATM_HUMAN",  "P53_HUMAN",  "P53_HUMAN"),
+            target      = c("P53_HUMAN",  "MDM2_HUMAN", "MDM2_HUMAN", "ATM_HUMAN"),
+            interaction = c("Phosphorylation", "Phosphorylation", "Activation", "Activation"),
+            site        = c("S15",         "T999",        NA,            "S15"),
+            stringsAsFactors = FALSE
+        )
+    }
     
-    result <- MSstatsBioNet:::.filterByPtmSite(nodes, edges, filter_by_ptm_site = TRUE)
+    test_that(".filterByPtmSite returns input unchanged when filter_by_ptm_site = FALSE", {
+        nodes  <- make_nodes()
+        edges  <- make_edges()
+        result <- MSstatsBioNet:::.filterByPtmSite(nodes, edges, filter_by_ptm_site = FALSE)
+        
+        expect_equal(nrow(result$nodes), nrow(nodes))
+        expect_equal(nrow(result$edges), nrow(edges))
+        expect_equal(result$nodes, nodes)
+        expect_equal(result$edges, edges)
+    })
     
-    expect_equal(nrow(result$nodes), nrow(nodes))
-    expect_equal(nrow(result$edges), nrow(edges))
+    test_that(".filterByPtmSite returns input unchanged when no nodes have Site data", {
+        nodes       <- make_nodes()
+        nodes$Site  <- NA   # wipe all sites
+        edges       <- make_edges()
+        
+        result <- MSstatsBioNet:::.filterByPtmSite(nodes, edges, filter_by_ptm_site = TRUE)
+        
+        expect_equal(nrow(result$nodes), nrow(nodes))
+        expect_equal(nrow(result$edges), nrow(edges))
+    })
+    
+    test_that(".filterByPtmSite keeps only edges with PTM site overlap on target node", {
+        result <- MSstatsBioNet:::.filterByPtmSite(make_nodes(), make_edges(),
+                                                   filter_by_ptm_site = TRUE)
+        # Only ATM→P53 with site=S15 should survive
+        expect_equal(nrow(result$edges), 1)
+        expect_equal(result$edges$source,      "ATM_HUMAN")
+        expect_equal(result$edges$target,      "P53_HUMAN")
+        expect_equal(result$edges$site,        "S15")
+    })
+    
+    test_that(".filterByPtmSite drops edges where edge site does not overlap node Site", {
+        result <- MSstatsBioNet:::.filterByPtmSite(make_nodes(), make_edges(),
+                                                   filter_by_ptm_site = TRUE)
+        # ATM→MDM2 with site=T999 should be gone (T999 not in MDM2's T68)
+        dropped <- result$edges[result$edges$source == "ATM_HUMAN" &
+                                    result$edges$target == "MDM2_HUMAN", ]
+        expect_equal(nrow(dropped), 0)
+    })
+    
+    test_that(".filterByPtmSite drops edges with NA edge site even if node has Site data", {
+        result <- MSstatsBioNet:::.filterByPtmSite(make_nodes(), make_edges(),
+                                                   filter_by_ptm_site = TRUE)
+        # P53→MDM2 has site=NA so must be dropped
+        dropped <- result$edges[result$edges$source == "P53_HUMAN" &
+                                    result$edges$target == "MDM2_HUMAN", ]
+        expect_equal(nrow(dropped), 0)
+    })
+    
+    test_that(".filterByPtmSite drops edges where target node has no Site data", {
+        result <- MSstatsBioNet:::.filterByPtmSite(make_nodes(), make_edges(),
+                                                   filter_by_ptm_site = TRUE)
+        # P53→ATM: ATM node Site is NA so no overlap possible
+        dropped <- result$edges[result$edges$source == "P53_HUMAN" &
+                                    result$edges$target == "ATM_HUMAN", ]
+        expect_equal(nrow(dropped), 0)
+    })
+    
+    test_that(".filterByPtmSite prunes nodes to only those in surviving edges", {
+        result <- MSstatsBioNet:::.filterByPtmSite(make_nodes(), make_edges(),
+                                                   filter_by_ptm_site = TRUE)
+        # Only ATM_HUMAN (source) and P53_HUMAN (target) should remain
+        expect_setequal(result$nodes$id, c("ATM_HUMAN", "P53_HUMAN"))
+        expect_false("MDM2_HUMAN" %in% result$nodes$id)
+    })
+    
+    test_that(".filterByPtmSite preserves all node columns after pruning", {
+        result <- MSstatsBioNet:::.filterByPtmSite(make_nodes(), make_edges(),
+                                                   filter_by_ptm_site = TRUE)
+        expect_true(all(c("id", "logFC", "Site") %in% names(result$nodes)))
+    })
+    
+    test_that(".filterByPtmSite keeps edge when site matches any of multiple node sites", {
+        nodes <- data.frame(
+            id   = c("A", "B"),
+            Site = c("S15_S20_T68", NA),
+            stringsAsFactors = FALSE
+        )
+        edges <- data.frame(
+            source      = "A",
+            target      = "B",
+            interaction = "Phosphorylation",
+            site        = "S20",    # matches second site in A's Site string
+            stringsAsFactors = FALSE
+        )
+        # Note: filter checks target node — B has no Site, so this should drop.
+        # Swap so A is the target to test multi-site matching.
+        edges2 <- data.frame(
+            source      = "B",
+            target      = "A",
+            interaction = "Phosphorylation",
+            site        = "S20",
+            stringsAsFactors = FALSE
+        )
+        result <- MSstatsBioNet:::.filterByPtmSite(nodes, edges2, filter_by_ptm_site = TRUE)
+        expect_equal(nrow(result$edges), 1)
+        expect_equal(result$edges$site, "S20")
+    })
+    
+    test_that(".filterByPtmSite handles empty edges gracefully", {
+        nodes <- make_nodes()
+        empty_edges <- data.frame(
+            source = character(0), target = character(0),
+            interaction = character(0), site = character(0),
+            stringsAsFactors = FALSE
+        )
+        result <- MSstatsBioNet:::.filterByPtmSite(nodes, empty_edges,
+                                                   filter_by_ptm_site = TRUE)
+        expect_equal(nrow(result$edges), 0)
+        # All nodes pruned since no edges reference them
+        expect_equal(nrow(result$nodes), 0)
+    })
+    
+    test_that(".filterByPtmSite handles empty nodes gracefully", {
+        empty_nodes <- data.frame(
+            id = character(0), Site = character(0),
+            stringsAsFactors = FALSE
+        )
+        edges <- make_edges()
+        # No nodes have Site data so passthrough expected
+        result <- MSstatsBioNet:::.filterByPtmSite(empty_nodes, edges,
+                                                   filter_by_ptm_site = TRUE)
+        expect_equal(nrow(result$edges), nrow(edges))
+    })
+    
+    test_that(".filterByPtmSite always returns a list with nodes and edges", {
+        result <- MSstatsBioNet:::.filterByPtmSite(make_nodes(), make_edges(),
+                                                   filter_by_ptm_site = TRUE)
+        expect_type(result, "list")
+        expect_true(all(c("nodes", "edges") %in% names(result)))
+        expect_s3_class(result$nodes, "data.frame")
+        expect_s3_class(result$edges, "data.frame")
+    })
 })
 
-test_that(".filterByPtmSite keeps only edges with PTM site overlap on target node", {
-    result <- MSstatsBioNet:::.filterByPtmSite(make_nodes(), make_edges(),
-                                                  filter_by_ptm_site = TRUE)
-    # Only ATM→P53 with site=S15 should survive
-    expect_equal(nrow(result$edges), 1)
-    expect_equal(result$edges$source,      "ATM_HUMAN")
-    expect_equal(result$edges$target,      "P53_HUMAN")
-    expect_equal(result$edges$site,        "S15")
-})
-
-test_that(".filterByPtmSite drops edges where edge site does not overlap node Site", {
-    result <- MSstatsBioNet:::.filterByPtmSite(make_nodes(), make_edges(),
-                                                  filter_by_ptm_site = TRUE)
-    # ATM→MDM2 with site=T999 should be gone (T999 not in MDM2's T68)
-    dropped <- result$edges[result$edges$source == "ATM_HUMAN" &
-                                result$edges$target == "MDM2_HUMAN", ]
-    expect_equal(nrow(dropped), 0)
-})
-
-test_that(".filterByPtmSite drops edges with NA edge site even if node has Site data", {
-    result <- MSstatsBioNet:::.filterByPtmSite(make_nodes(), make_edges(),
-                                                  filter_by_ptm_site = TRUE)
-    # P53→MDM2 has site=NA so must be dropped
-    dropped <- result$edges[result$edges$source == "P53_HUMAN" &
-                                result$edges$target == "MDM2_HUMAN", ]
-    expect_equal(nrow(dropped), 0)
-})
-
-test_that(".filterByPtmSite drops edges where target node has no Site data", {
-    result <- MSstatsBioNet:::.filterByPtmSite(make_nodes(), make_edges(),
-                                                  filter_by_ptm_site = TRUE)
-    # P53→ATM: ATM node Site is NA so no overlap possible
-    dropped <- result$edges[result$edges$source == "P53_HUMAN" &
-                                result$edges$target == "ATM_HUMAN", ]
-    expect_equal(nrow(dropped), 0)
-})
-
-test_that(".filterByPtmSite prunes nodes to only those in surviving edges", {
-    result <- MSstatsBioNet:::.filterByPtmSite(make_nodes(), make_edges(),
-                                                  filter_by_ptm_site = TRUE)
-    # Only ATM_HUMAN (source) and P53_HUMAN (target) should remain
-    expect_setequal(result$nodes$id, c("ATM_HUMAN", "P53_HUMAN"))
-    expect_false("MDM2_HUMAN" %in% result$nodes$id)
-})
-
-test_that(".filterByPtmSite preserves all node columns after pruning", {
-    result <- MSstatsBioNet:::.filterByPtmSite(make_nodes(), make_edges(),
-                                                  filter_by_ptm_site = TRUE)
-    expect_true(all(c("id", "logFC", "Site") %in% names(result$nodes)))
-})
-
-test_that(".filterByPtmSite keeps edge when site matches any of multiple node sites", {
-    nodes <- data.frame(
-        id   = c("A", "B"),
-        Site = c("S15_S20_T68", NA),
-        stringsAsFactors = FALSE
-    )
-    edges <- data.frame(
-        source      = "A",
-        target      = "B",
-        interaction = "Phosphorylation",
-        site        = "S20",    # matches second site in A's Site string
-        stringsAsFactors = FALSE
-    )
-    # Note: filter checks target node — B has no Site, so this should drop.
-    # Swap so A is the target to test multi-site matching.
-    edges2 <- data.frame(
-        source      = "B",
-        target      = "A",
-        interaction = "Phosphorylation",
-        site        = "S20",
-        stringsAsFactors = FALSE
-    )
-    result <- MSstatsBioNet:::.filterByPtmSite(nodes, edges2, filter_by_ptm_site = TRUE)
-    expect_equal(nrow(result$edges), 1)
-    expect_equal(result$edges$site, "S20")
-})
-
-test_that(".filterByPtmSite handles empty edges gracefully", {
-    nodes <- make_nodes()
-    empty_edges <- data.frame(
-        source = character(0), target = character(0),
-        interaction = character(0), site = character(0),
-        stringsAsFactors = FALSE
-    )
-    result <- MSstatsBioNet:::.filterByPtmSite(nodes, empty_edges,
-                                                  filter_by_ptm_site = TRUE)
-    expect_equal(nrow(result$edges), 0)
-    # All nodes pruned since no edges reference them
-    expect_equal(nrow(result$nodes), 0)
-})
-
-test_that(".filterByPtmSite handles empty nodes gracefully", {
-    empty_nodes <- data.frame(
-        id = character(0), Site = character(0),
-        stringsAsFactors = FALSE
-    )
-    edges <- make_edges()
-    # No nodes have Site data so passthrough expected
-    result <- MSstatsBioNet:::.filterByPtmSite(empty_nodes, edges,
-                                                  filter_by_ptm_site = TRUE)
-    expect_equal(nrow(result$edges), nrow(edges))
-})
-
-test_that(".filterByPtmSite always returns a list with nodes and edges", {
-    result <- MSstatsBioNet:::.filterByPtmSite(make_nodes(), make_edges(),
-                                                  filter_by_ptm_site = TRUE)
-    expect_type(result, "list")
-    expect_true(all(c("nodes", "edges") %in% names(result)))
-    expect_s3_class(result$nodes, "data.frame")
-    expect_s3_class(result$edges, "data.frame")
+describe(".filterGetSubnetworkFromIndraInput", {
+    .make_test_input <- function() {
+        data.frame(
+            Protein   = c("A", "B", "C", "D"),
+            log2FC    = c(3, -3, 0.5, Inf),
+            adj.pvalue = c(0.01, 0.01, 0.5, 0.01),
+            stringsAsFactors = FALSE
+        )
+    }
+    
+    test_that(".filterGetSubnetworkFromIndraInput filters by pvalueCutoff", {
+        result <- MSstatsBioNet:::.filterGetSubnetworkFromIndraInput(
+            .make_test_input(), pvalueCutoff = 0.05, logfc_cutoff = NULL,
+            force_include_other = NULL, include_infinite_fc = FALSE, direction = "both"
+        )
+        expect_true(all(result$adj.pvalue < 0.05))
+    })
+    
+    test_that(".filterGetSubnetworkFromIndraInput filters by logfc_cutoff", {
+        result <- MSstatsBioNet:::.filterGetSubnetworkFromIndraInput(
+            .make_test_input(), pvalueCutoff = NULL, logfc_cutoff = 1,
+            force_include_other = NULL, include_infinite_fc = FALSE, direction = "both"
+        )
+        expect_true(all(abs(result$log2FC) > 1))
+    })
+    
+    test_that(".filterGetSubnetworkFromIndraInput respects force_include_other", {
+        input <- cbind(.make_test_input(), HgncId = c("1", "2", "3", "4"))
+        result <- MSstatsBioNet:::.filterGetSubnetworkFromIndraInput(
+            input, pvalueCutoff = 0.001, logfc_cutoff = 10,
+            force_include_other = c("HGNC:1"), include_infinite_fc = FALSE, direction = "both"
+        )
+        expect_true("A" %in% result$Protein)
+    })
+    
+    test_that(".filterGetSubnetworkFromIndraInput includes infinite FC when requested", {
+        result <- MSstatsBioNet:::.filterGetSubnetworkFromIndraInput(
+            .make_test_input(), pvalueCutoff = NULL, logfc_cutoff = 5,
+            force_include_other = NULL, include_infinite_fc = TRUE, direction = "both"
+        )
+        expect_true("D" %in% result$Protein)
+    })
+    
+    test_that(".filterGetSubnetworkFromIndraInput filters by direction up", {
+        result <- MSstatsBioNet:::.filterGetSubnetworkFromIndraInput(
+            .make_test_input(), pvalueCutoff = NULL, logfc_cutoff = NULL,
+            force_include_other = NULL, include_infinite_fc = FALSE, direction = "up"
+        )
+        expect_true(all(result$log2FC > 0))
+    })
+    
+    test_that(".filterGetSubnetworkFromIndraInput filters by direction down", {
+        result <- MSstatsBioNet:::.filterGetSubnetworkFromIndraInput(
+            .make_test_input(), pvalueCutoff = NULL, logfc_cutoff = NULL,
+            force_include_other = NULL, include_infinite_fc = FALSE, direction = "down"
+        )
+        expect_true(all(result$log2FC < 0))
+    })
 })


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation and Context

This PR adds support for including proteins with infinite log fold change values in network construction from INDRA and adds directional filtering for regulation. Proteins with infinite logFC arise when they are observed in only one experimental condition (e.g., zero in one condition and non-zero in the other); previously these proteins could be excluded. The new options give users explicit control to include such proteins and to filter by regulation direction ("both", "up", "down") while preserving backward compatibility.

## Solution Summary

- Public API: getSubnetworkFromIndra gains two new parameters:
  - include_infinite_fc (logical, default FALSE) — whether to include proteins with infinite log2 fold change.
  - direction (one of "both", "up", "down") — direction-based filtering of log2FC.
- Filtering pipeline: include_infinite_fc and direction are propagated into the internal input-filtering routine, which now can collect and prepend infinite-logFC proteins, apply directional filtering, and deduplicate before downstream INDRA processing.
- Visualization: logFC→color mapping was updated to handle positive/negative infinity by clamping infinite values to finite computed bounds so color scales remain stable.
- Metadata: new internal helper .addAdditionalMetadataToIndraEdge(edge, input) was introduced to enrich INDRA edge metadata from the filtered input.

## Detailed Changes

- R/getSubnetworkFromIndra.R
  - Added parameters include_infinite_fc = FALSE and direction (c("both","up","down")) to the function signature and Roxygen docs.
  - Call to .filterGetSubnetworkFromIndraInput updated to pass include_infinite_fc and direction.

- R/utils_getSubnetworkFromIndra.R
  - .filterGetSubnetworkFromIndraInput signature expanded to accept include_infinite_fc and direction.
  - Implemented detection of proteins with infinite log2FC (is.infinite) when include_infinite_fc is TRUE and integration of those proteins with exempt/filtered sets, followed by deduplication.
  - Added directional filtering logic (both/up/down) applied to filtered input.
  - Removed prior ad-hoc filtering based on an "issue" column.
  - Added internal helper .addAdditionalMetadataToIndraEdge(edge, input) to attach extra metadata (e.g., PTM site extraction and GlobalProtein mapping) to INDRA edges.

- R/utils_cytoscapeNetwork.R
  - Updated .mapLogFCToColor to:
    - Identify positive and negative infinities and compute finite_values for scale computation.
    - Compute max_logFC from finite absolute values with fallback default_max = 2, set min_logFC = -max_logFC.
    - Clamp infinite logFC entries to min/max before normalization so color mapping handles infinities correctly.
    - Preserve NA handling (mapped to middle color).

- man/getSubnetworkFromIndra.Rd
  - Documentation updated to include include_infinite_fc and direction parameters and their descriptions.

- Minor: Roxygen and function documentation updated to reflect new parameters.

## Unit Tests

- New unit tests were added in this PR to cover:
  - include_infinite_fc behavior (including/integrating infinite-logFC proteins).
  - direction filtering ("both"/"up"/"down") behavior.
  - Infinite value clamping in .mapLogFCToColor (positive/negative infinities).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->