### PR TITLE
fix quoted bug

### DIFF
--- a/R/cytoscapeNetwork.R
+++ b/R/cytoscapeNetwork.R
@@ -560,7 +560,7 @@ cytoscapeNetworkOutput <- function(outputId,
 #' }
 #' @export
 renderCytoscapeNetwork <- function(expr, env = parent.frame()) {
-    if (!quoted) expr <- substitute(expr)
+    expr <- substitute(expr)
     htmlwidgets::shinyRenderWidget(
         expr    = expr,
         outputFunction = cytoscapeNetworkOutput,


### PR DESCRIPTION
# Motivation and Context

Please include relevant motivation and context of the problem along with a short summary of the solution.

## Changes

Please provide a detailed bullet point list of your changes.

- 

## Testing

Please describe any unit tests you added or modified to verify your changes.

## Checklist Before Requesting a Review
- [ ] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Ran styler::style_pkg(transformers = styler::tidyverse_style(indent_by = 4))
- [ ] Ran devtools::document()


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and Context

The `renderCytoscapeNetwork()` function contained a critical bug where it referenced an undefined variable `quoted` in a conditional statement. The function signature only includes `expr` and `env` parameters, but the code attempted to check `if (!quoted)` before calling `substitute(expr)`. This would cause a runtime error whenever the function is invoked in a Shiny application, as the `quoted` variable does not exist in the function's scope.

The fix simplifies the logic by unconditionally calling `substitute(expr)` before passing the expression to `htmlwidgets::shinyRenderWidget()` with `quoted = TRUE`. This is the correct pattern for Shiny render functions that need to capture the unevaluated expression from the caller.

## Changes

- **R/cytoscapeNetwork.R**: Modified `renderCytoscapeNetwork()` function to remove the undefined `quoted` variable reference and unconditionally call `substitute(expr)` on the input expression before passing it to `htmlwidgets::shinyRenderWidget()`. The `quoted` argument to `shinyRenderWidget()` remains `TRUE`, ensuring proper expression handling in the widget rendering pipeline.

## Unit Tests

The existing test suite in `tests/testthat/test-utils_cytoscapeNetwork.R` covers the helper functions and the public `cytoscapeNetwork()` API, including validation of input parameters, element building, and widget creation. These tests verify the core functionality of the network visualization pipeline. However, no explicit unit tests are documented in the PR for the `renderCytoscapeNetwork()` function itself, which would typically be integration-tested within a Shiny application context.

## Coding Guidelines

No violations of coding guidelines are evident in this change. The fix aligns with standard R/Shiny patterns for render functions and represents a straightforward bug correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->