### PR TITLE
Feat delete

### DIFF
--- a/inst/htmlwidgets/cytoscapeNetwork.js
+++ b/inst/htmlwidgets/cytoscapeNetwork.js
@@ -436,11 +436,50 @@ HTMLWidgets.widget({
           tooltip.style.display = "none";
         });
 
-        /* ── Evidence link on edge click ─────────────────────────────── */
+        /* ── Right-click on edge → delete it ────────────────────────── */
+
+        /* Record which mouse button started the current click so the tap
+           handler can tell left from right without relying on Cytoscape's
+           originalEvent (which is unreliable for button detection). */
+        var lastMouseButton = 0;
+        cyContainer.addEventListener("mousedown", function (evt) {
+          lastMouseButton = evt.button;
+        });
+
+        /* Track whichever non-PTM edge the cursor is currently over */
+        var hoveredEdge = null;
+        cy.on("mouseover", "edge", function (evt) {
+          var e = evt.target;
+          if (e.data("edge_type") !== "ptm_attachment") hoveredEdge = e;
+        });
+        cy.on("mouseout", "edge", function () {
+          hoveredEdge = null;
+        });
+
+        /* contextmenu fires reliably on right-click before the browser
+           can show its native menu; preventDefault stops the native menu */
+        cyContainer.addEventListener("contextmenu", function (evt) {
+          evt.preventDefault();
+          if (!hoveredEdge || !hoveredEdge.inside()) return;
+          var deleted = {
+            source:      hoveredEdge.data("source"),
+            target:      hoveredEdge.data("target"),
+            interaction: hoveredEdge.data("interaction")
+          };
+          hoveredEdge.remove();
+          hoveredEdge = null;
+          if (window.Shiny) {
+            Shiny.setInputValue(el.id + "_edge_deleted", deleted, { priority: "event" });
+          }
+        });
+
+        /* ── Evidence link on left-click ────────────────────────────── */
         cy.on("tap", "edge", function (evt) {
           var edge = evt.target;
           // skip compound/ptm attachment edges
           if (edge.data("edge_type") === "ptm_attachment") return;
+          // skip right-click — handled by the contextmenu listener above
+          if (lastMouseButton === 2) return;
           openSafe(edge.data("evidenceLink"));
           if (window.Shiny) {
             Shiny.setInputValue(el.id + "_edge_clicked", {

--- a/inst/htmlwidgets/cytoscapeNetwork.js
+++ b/inst/htmlwidgets/cytoscapeNetwork.js
@@ -438,13 +438,14 @@ HTMLWidgets.widget({
 
         /* ── Right-click on edge → delete it ────────────────────────── */
 
-        /* Record which mouse button started the current click so the tap
-           handler can tell left from right without relying on Cytoscape's
-           originalEvent (which is unreliable for button detection). */
-        var lastMouseButton = 0;
+        /* Block right-click mousedown from reaching Cytoscape by intercepting
+           it in the capture phase (runs before any element-level listener).
+           This prevents Cytoscape from ever starting a tap cycle on right-click,
+           stopping the evidence link from opening. The contextmenu event is
+           fired by the OS independently and is unaffected by this. */
         cyContainer.addEventListener("mousedown", function (evt) {
-          lastMouseButton = evt.button;
-        });
+          if (evt.button === 2) evt.stopImmediatePropagation();
+        }, true);
 
         /* Track whichever non-PTM edge the cursor is currently over */
         var hoveredEdge = null;
@@ -478,8 +479,6 @@ HTMLWidgets.widget({
           var edge = evt.target;
           // skip compound/ptm attachment edges
           if (edge.data("edge_type") === "ptm_attachment") return;
-          // skip right-click — handled by the contextmenu listener above
-          if (lastMouseButton === 2) return;
           openSafe(edge.data("evidenceLink"));
           if (window.Shiny) {
             Shiny.setInputValue(el.id + "_edge_clicked", {

--- a/inst/htmlwidgets/cytoscapeNetwork.js
+++ b/inst/htmlwidgets/cytoscapeNetwork.js
@@ -247,6 +247,18 @@ HTMLWidgets.widget({
         '<div style="margin-top:8px;padding:7px;background:#fff3cd;border-radius:4px;font-size:10px;line-height:1.4;">' +
         '<strong>Delete edge:</strong> Right-click or Ctrl+Click an edge to remove it from the network.</div>';
     }
+    
+    // Helper to delete an edge and notify Shiny
+    function deleteEdge(edge) {
+      if (window.Shiny) {
+        Shiny.setInputValue(el.id + "_edge_deleted", {
+          source:      edge.data("source"),
+          target:      edge.data("target"),
+          interaction: edge.data("interaction")
+        }, { priority: "event" });
+      }
+      edge.remove();
+    }
 
     /* ── renderValue ──────────────────────────────────────────────────── */
     return {
@@ -438,61 +450,18 @@ HTMLWidgets.widget({
           tooltip.style.display = "none";
         });
 
-        /* ── Right-click on edge → delete it ────────────────────────── */
-
-        /* Block right-click mousedown from reaching Cytoscape by intercepting
-           it in the capture phase (runs before any element-level listener).
-           This prevents Cytoscape from ever starting a tap cycle on right-click,
-           stopping the evidence link from opening. The contextmenu event is
-           fired by the OS independently and is unaffected by this. */
-        cyContainer.addEventListener("mousedown", function (evt) {
-          if (evt.button === 2) evt.stopImmediatePropagation();
-        }, true);
-
-        /* Track whichever non-PTM edge the cursor is currently over */
-        var hoveredEdge = null;
-        cy.on("mouseover", "edge", function (evt) {
-          var e = evt.target;
-          if (e.data("edge_type") !== "ptm_attachment") hoveredEdge = e;
-        });
-        cy.on("mouseout", "edge", function () {
-          hoveredEdge = null;
-        });
-
-        /* contextmenu fires reliably on right-click before the browser
-           can show its native menu; preventDefault stops the native menu */
-        cyContainer.addEventListener("contextmenu", function (evt) {
-          evt.preventDefault();
-          if (!hoveredEdge || !hoveredEdge.inside()) return;
-          var deleted = {
-            source:      hoveredEdge.data("source"),
-            target:      hoveredEdge.data("target"),
-            interaction: hoveredEdge.data("interaction")
-          };
-          hoveredEdge.remove();
-          hoveredEdge = null;
-          if (window.Shiny) {
-            Shiny.setInputValue(el.id + "_edge_deleted", deleted, { priority: "event" });
-          }
-        });
+        // Suppress the native context menu
+        cyContainer.addEventListener("contextmenu", e => e.preventDefault());
 
         /* ── Edge tap: Ctrl+Click → delete; plain click → evidence link ── */
-        cy.on("tap", "edge", function (evt) {
+        cy.on("cxttap tap", "edge", function (evt) {
           var edge = evt.target;
           // skip ptm attachment edges
           if (edge.data("edge_type") === "ptm_attachment") return;
 
-          // Ctrl+Click → delete edge
-          if (evt.originalEvent && evt.originalEvent.ctrlKey) {
-            var deleted = {
-              source:      edge.data("source"),
-              target:      edge.data("target"),
-              interaction: edge.data("interaction")
-            };
-            edge.remove();
-            if (window.Shiny) {
-              Shiny.setInputValue(el.id + "_edge_deleted", deleted, { priority: "event" });
-            }
+          // Ctrl+Click or Right Click → delete edge
+          if (evt.type === "cxttap" || (evt.originalEvent && evt.originalEvent.ctrlKey)) {
+            deleteEdge(edge);
             return;
           }
 

--- a/inst/htmlwidgets/cytoscapeNetwork.js
+++ b/inst/htmlwidgets/cytoscapeNetwork.js
@@ -450,9 +450,6 @@ HTMLWidgets.widget({
           tooltip.style.display = "none";
         });
 
-        // Suppress the native context menu
-        cyContainer.addEventListener("contextmenu", e => e.preventDefault());
-
         /* ── Edge tap: Ctrl+Click → delete; plain click → evidence link ── */
         cy.on("cxttap tap", "edge", function (evt) {
           var edge = evt.target;

--- a/inst/htmlwidgets/cytoscapeNetwork.js
+++ b/inst/htmlwidgets/cytoscapeNetwork.js
@@ -459,6 +459,7 @@ HTMLWidgets.widget({
           // Ctrl+Click or Right Click → delete edge
           if (evt.type === "cxttap" || (evt.originalEvent && evt.originalEvent.ctrlKey)) {
             deleteEdge(edge);
+            buildLegend(cy, legendPanel);
             return;
           }
 

--- a/inst/htmlwidgets/cytoscapeNetwork.js
+++ b/inst/htmlwidgets/cytoscapeNetwork.js
@@ -243,7 +243,9 @@ HTMLWidgets.widget({
         '  </div></div>' +
         (edgeItems ? '<div style="font-weight:bold;margin-bottom:6px;font-size:13px;">Edge types</div>' + edgeItems : '') +
         '<div style="margin-top:12px;padding:7px;background:#e3f2fd;border-radius:4px;font-size:10px;line-height:1.4;">' +
-        '<strong>PTM info:</strong> Hover over edges to see overlapping PTM sites.</div>';
+        '<strong>PTM info:</strong> Hover over edges to see overlapping PTM sites.</div>' +
+        '<div style="margin-top:8px;padding:7px;background:#fff3cd;border-radius:4px;font-size:10px;line-height:1.4;">' +
+        '<strong>Delete edge:</strong> Right-click or Ctrl+Click an edge to remove it from the network.</div>';
     }
 
     /* ── renderValue ──────────────────────────────────────────────────── */

--- a/inst/htmlwidgets/cytoscapeNetwork.js
+++ b/inst/htmlwidgets/cytoscapeNetwork.js
@@ -474,11 +474,27 @@ HTMLWidgets.widget({
           }
         });
 
-        /* ── Evidence link on left-click ────────────────────────────── */
+        /* ── Edge tap: Ctrl+Click → delete; plain click → evidence link ── */
         cy.on("tap", "edge", function (evt) {
           var edge = evt.target;
-          // skip compound/ptm attachment edges
+          // skip ptm attachment edges
           if (edge.data("edge_type") === "ptm_attachment") return;
+
+          // Ctrl+Click → delete edge
+          if (evt.originalEvent && evt.originalEvent.ctrlKey) {
+            var deleted = {
+              source:      edge.data("source"),
+              target:      edge.data("target"),
+              interaction: edge.data("interaction")
+            };
+            edge.remove();
+            if (window.Shiny) {
+              Shiny.setInputValue(el.id + "_edge_deleted", deleted, { priority: "event" });
+            }
+            return;
+          }
+
+          // Plain click → open evidence link
           openSafe(edge.data("evidenceLink"));
           if (window.Shiny) {
             Shiny.setInputValue(el.id + "_edge_clicked", {


### PR DESCRIPTION
## Motivation and Context

The PR adds interactive edge deletion functionality to the Cytoscape network visualization widget. Users can now remove edges (connections between proteins) directly from the network by right-clicking or using Ctrl+Click, enabling dynamic network refinement and exploration. The feature maintains backward compatibility by keeping plain left-click behavior for opening evidence links.

## Solution Summary

The implementation introduces a `deleteEdge()` helper function in the JavaScript widget that removes edges from the graph and notifies the R/Shiny server of deletions. The event handler logic was refactored to support both deletion (right-click/Ctrl+Click) and navigation (plain click) actions on edges, with the "prevent default" behavior removed as indicated in the commit message.

## Detailed Changes

- **Updated legend/help text** with a new section instructing users: "Right-click or Ctrl+Click an edge to remove it from the network"
- **Added `deleteEdge(edge)` helper function** that:
  - Sends a Shiny input event named `${el.id}_edge_deleted` containing the deleted edge's `source`, `target`, and `interaction` properties when Shiny is available
  - Removes the edge from the Cytoscape graph instance
  - Uses priority "event" for immediate Shiny notification
- **Refactored edge event handler** from single `tap` handler to combined `"cxttap tap"` handler:
  - Right-click (cxttap event) or Ctrl+Click triggers `deleteEdge()`
  - Plain left-click continues to open evidence links and sends `${el.id}_edge_clicked` event
  - PTM attachment edges are exempt from deletion to preserve visualization integrity
- **Removed preventDefault() logic** from edge interactions as per the commit message

## Testing

No new unit tests have been added or modified to verify the edge deletion functionality. The existing test file `tests/testthat/test-utils_cytoscapeNetwork.R` does not include tests for the JavaScript widget's interactive features or the new deletion capability.

## Coding Guidelines

The implementation adheres to the existing code standards:
- JavaScript code follows established formatting conventions with proper indentation and clear comments
- Helper function includes descriptive comments explaining the deletion and notification process
- Appropriate conditional checks for Shiny availability before attempting event notifications
- Guard clause to prevent deletion of PTM attachment edges

<!-- end of auto-generated comment: release notes by coderabbit.ai -->