### PR TITLE
fix bug for inf fc

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,5 @@
 ^docs$
 ^pkgdown$
 ^\.github$
+^\.positai$
+^\.claude$

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /doc/
 /Meta/
 docs
+.positai

--- a/R/utils_getSubnetworkFromIndra.R
+++ b/R/utils_getSubnetworkFromIndra.R
@@ -167,7 +167,9 @@
     if (include_infinite_fc) {
         infinite_fc_proteins <- input[is.infinite(input$log2FC), ]
     } else {
-        input <- input[!is.infinite(input$log2FC), ]
+        if ("log2FC" %in% colnames(input)) {
+            input <- input[!is.infinite(input$log2FC), ]
+        }
     }
 
     input <- input[!is.na(input$adj.pvalue),]

--- a/R/utils_getSubnetworkFromIndra.R
+++ b/R/utils_getSubnetworkFromIndra.R
@@ -166,6 +166,8 @@
     infinite_fc_proteins <- NULL
     if (include_infinite_fc) {
         infinite_fc_proteins <- input[is.infinite(input$log2FC), ]
+    } else {
+        input <- input[!is.infinite(input$log2FC), ]
     }
 
     input <- input[!is.na(input$adj.pvalue),]

--- a/tests/testthat/test-utils_getSubnetworkFromIndra.R
+++ b/tests/testthat/test-utils_getSubnetworkFromIndra.R
@@ -196,6 +196,38 @@ describe(".filterGetSubnetworkFromIndraInput", {
         )
         expect_true("D" %in% result$Protein)
     })
+
+    test_that(".filterGetSubnetworkFromIndraInput excludes infinite FC proteins with adj.pvalue=0 when include_infinite_fc is FALSE", {
+        # MSstats sets adj.pvalue=0 for infinite FC proteins; they must still be excluded
+        input <- data.frame(
+            Protein   = c("A", "B", "D"),
+            log2FC    = c(3, -3, Inf),
+            adj.pvalue = c(0.01, 0.01, 0),
+            stringsAsFactors = FALSE
+        )
+        result <- MSstatsBioNet:::.filterGetSubnetworkFromIndraInput(
+            input, pvalueCutoff = 0.05, logfc_cutoff = NULL,
+            force_include_other = NULL, include_infinite_fc = FALSE, direction = "both"
+        )
+        expect_false("D" %in% result$Protein)
+    })
+
+    test_that(".filterGetSubnetworkFromIndraInput includes infinite FC protein via force_include_other even when include_infinite_fc is FALSE", {
+        input <- cbind(
+            data.frame(
+                Protein   = c("A", "B", "D"),
+                log2FC    = c(3, -3, Inf),
+                adj.pvalue = c(0.01, 0.01, 0),
+                stringsAsFactors = FALSE
+            ),
+            HgncId = c("1", "2", "4")
+        )
+        result <- MSstatsBioNet:::.filterGetSubnetworkFromIndraInput(
+            input, pvalueCutoff = 0.05, logfc_cutoff = NULL,
+            force_include_other = c("HGNC:4"), include_infinite_fc = FALSE, direction = "both"
+        )
+        expect_true("D" %in% result$Protein)
+    })
     
     test_that(".filterGetSubnetworkFromIndraInput filters by direction up", {
         result <- MSstatsBioNet:::.filterGetSubnetworkFromIndraInput(


### PR DESCRIPTION

## Motivation and Context

This PR fixes a bug in the filtering logic for handling infinite fold change (log2FC) values in .filterGetSubnetworkFromIndraInput. Previously, when include_infinite_fc was FALSE, rows with infinite log2FC could remain in the input (causing adj.pvalue == 0 entries and other downstream issues). The change makes removal of infinite log2FC conditional on the presence of a log2FC column and ensures infinite values are excluded when include_infinite_fc is FALSE while still allowing explicit inclusion or force-inclusion behavior.

## Changes

- R/utils_getSubnetworkFromIndra.R
  - .filterGetSubnetworkFromIndraInput:
    - Added conditional filtering so infinite log2FC rows are actively removed when include_infinite_fc = FALSE, but only if a "log2FC" column exists:
      - if ("log2FC" %in% colnames(input)) { input <- input[!is.infinite(input$log2FC), ] }
    - Retains behavior of collecting infinite FC rows into infinite_fc_proteins when include_infinite_fc = TRUE and later recombining them (with de-duplication).
    - Preserves force_include_other exemption logic (exempt rows are re-added after filtering).
- tests/testthat/test-utils_getSubnetworkFromIndra.R
  - Added tests that exercise the infinite-FC handling and force-inclusion behavior (see Testing section).
- .Rbuildignore
  - Added .positai and .claude to ignore rules.
- .gitignore
  - Added .positai to ignore rules.

## Testing

- tests/testthat/test-utils_getSubnetworkFromIndra.R
  - New tests for .filterGetSubnetworkFromIndraInput:
    - Verifies that infinite-FC proteins with adj.pvalue == 0 are excluded when include_infinite_fc = FALSE.
    - Verifies that an infinite-FC protein can still be included via force_include_other (e.g., "HGNC:...") even when include_infinite_fc = FALSE.
  - Existing tests covering p-value cutoff, logFC cutoff, direction filtering, and force_include_other behavior remain and continue to validate related behaviors.

## Coding guidelines / violations

- None detected in the changed files. The edits are small, internal, and follow existing style and error-checking conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->