### PR TITLE
Gate the PTM legend callout on PTM data presence

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: MSstatsBioNet
 Type: Package
 Title: Network Analysis for MS-based Proteomics Experiments
-Version: 1.5.1
+Version: 1.5.2
 Authors@R: c(
     person("Anthony", "Wu", email = "wu.anthon@northeastern.edu", 
         role = c("aut", "cre"), comment = c(ORCID = "0009-0001-7391-9902")),

--- a/inst/htmlwidgets/cytoscapeNetwork.js
+++ b/inst/htmlwidgets/cytoscapeNetwork.js
@@ -226,6 +226,8 @@ HTMLWidgets.widget({
         })
         .join("");
 
+      var hasPtm = cyInstance.nodes('[node_type = "ptm"]').length > 0;
+
       legendEl.innerHTML =
         '<div style="font-weight:bold;margin-bottom:8px;font-size:13px;">Node color (logFC)</div>' +
         '<div style="display:flex;align-items:flex-start;margin-bottom:12px;">' +
@@ -234,8 +236,10 @@ HTMLWidgets.widget({
         '    <span>Upregulated</span><span>Neutral</span><span>Downregulated</span>' +
         '  </div></div>' +
         (edgeItems ? '<div style="font-weight:bold;margin-bottom:6px;font-size:13px;">Edge types</div>' + edgeItems : '') +
-        '<div style="margin-top:12px;padding:7px;background:#e3f2fd;border-radius:4px;font-size:10px;line-height:1.4;">' +
-        '<strong>PTM info:</strong> Hover over edges to see overlapping PTM sites.</div>' +
+        (hasPtm
+          ? '<div style="margin-top:12px;padding:7px;background:#e3f2fd;border-radius:4px;font-size:10px;line-height:1.4;">' +
+            '<strong>PTM info:</strong> Hover over edges to see overlapping PTM sites.</div>'
+          : '') +
         '<div style="margin-top:8px;padding:7px;background:#fff3cd;border-radius:4px;font-size:10px;line-height:1.4;">' +
         '<strong>Delete edge:</strong> Right-click or Ctrl+Click an edge to remove it from the network.</div>';
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and Context

The PTM legend callout was displayed even when a network contained no PTM data, creating misleading UI content. The legend is now gated on the presence of PTM nodes, and the package version is bumped to 1.5.2.

## Changes

- Updated `inst/htmlwidgets/cytoscapeNetwork.js`:
  - Detects whether PTM nodes are present.
  - Displays the “PTM info” legend message only when PTM data exists.
- Updated `DESCRIPTION`:
  - Bumped package version from `1.5.1` to `1.5.2`.

## Unit Tests

- No unit tests were added or modified.

## Coding Guidelines

- No coding guideline violations were identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->